### PR TITLE
fix(ci): resolve Linux dep conflict and Windows path issue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
         if: matrix.platform == 'ubuntu-22.04'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev libssl-dev libayatana-appindicator3-dev
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev libssl-dev
 
       - uses: actions/download-artifact@v4
         with:
@@ -101,6 +101,7 @@ jobs:
       - run: pnpm install
 
       - name: Clone stremio-service fork
+        shell: bash
         run: git clone https://github.com/Aqu1tain/stremio-service "$RUNNER_TEMP/stremio-service"
 
       - name: Build stremio-service


### PR DESCRIPTION
- Remove `libayatana-appindicator3-dev` (conflicts with `libappindicator3-dev`)
- Add `shell: bash` to clone step so `$RUNNER_TEMP` resolves correctly on Windows