### PR TITLE
ci: add Rust build cache

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,12 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            src-tauri
+            ${{ runner.temp }}/stremio-service
+
       - name: Install Linux dependencies
         if: matrix.platform == 'ubuntu-22.04'
         run: |


### PR DESCRIPTION
Cache cargo artifacts for stremio-service and Tauri builds. First build unchanged, subsequent builds much faster.