### PR TITLE
Fix service binary path resolution on Linux/Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stremio-horizon-app",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "scripts": {
     "tauri": "tauri",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3300,7 +3300,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stremio-horizon-app"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stremio-horizon-app"
-version = "0.1.1"
+version = "0.1.2"
 description = "Desktop app for Stremio Horizon"
 authors = ["Aqu1tain"]
 edition = "2021"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,5 @@
-use std::path::PathBuf;
 use std::process::Command;
+use tauri::path::BaseDirectory;
 use tauri::webview::WebviewWindowBuilder;
 use tauri::{Manager, WebviewUrl};
 
@@ -33,35 +33,20 @@ fn create_window(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>>
 }
 
 fn spawn_service(app: &tauri::App) {
-    let name = service_name();
+    let name = if cfg!(windows) { "stremio-service.exe" } else { "stremio-service" };
 
-    let Some(dir) = find_service_dir(app, &name) else {
-        return;
+    let path = match app.path().resolve(format!("binaries/{name}"), BaseDirectory::Resource) {
+        Ok(p) if p.exists() => p,
+        _ => {
+            eprintln!("stremio-service binary not found in resources");
+            return;
+        }
     };
 
-    match Command::new(dir.join(&name)).current_dir(&dir).spawn() {
-        Ok(_) => println!("stremio-service started"),
+    let dir = path.parent().unwrap();
+
+    match Command::new(&path).current_dir(dir).spawn() {
+        Ok(_) => println!("stremio-service started from {}", dir.display()),
         Err(e) => eprintln!("stremio-service failed: {e}"),
-    }
-}
-
-fn find_service_dir(app: &tauri::App, name: &str) -> Option<PathBuf> {
-    let exe_dir = std::env::current_exe().ok()?.parent()?.to_path_buf();
-
-    if exe_dir.join(name).exists() {
-        return Some(exe_dir);
-    }
-
-    app.path()
-        .resource_dir()
-        .ok()
-        .filter(|d| d.join(name).exists())
-}
-
-fn service_name() -> &'static str {
-    if cfg!(windows) {
-        "stremio-service.exe"
-    } else {
-        "stremio-service"
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Stremio Horizon",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "identifier": "com.aqu1tain.stremio-horizon",
   "build": {
     "frontendDist": "../dist"


### PR DESCRIPTION
## Summary
- Use Tauri's `app.path().resolve()` API to locate service binaries instead of manual directory search
- Fixes stremio-service not starting on Linux and Windows
- Bump version to 0.1.2

## Test plan
- [ ] Verify service starts on macOS
- [ ] Verify service starts on Linux
- [ ] Verify service starts on Windows