### PR TITLE
fix: fullscreen bridge, TLS proxy, refactor

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2898,6 +2898,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2917,6 +2931,41 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -3300,7 +3349,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stremio-horizon-app"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3341,6 +3390,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swift-rs"
@@ -4140,15 +4195,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "ureq"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
 dependencies = [
  "base64 0.22.1",
+ "flate2",
  "log",
  "once_cell",
+ "rustls",
+ "rustls-pki-types",
  "url",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -4399,6 +4464,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.3",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b130c0d2d49f8b6889abc456e795e82525204f27c42cf767cf0d7734e089b8"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webview2-com"
 version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4626,6 +4709,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5089,6 +5181,12 @@ dependencies = [
  "syn 2.0.114",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3300,14 +3300,15 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stremio-horizon-app"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
- "tauri-plugin-localhost",
  "tauri-plugin-opener",
+ "tiny_http",
+ "ureq",
 ]
 
 [[package]]
@@ -3593,21 +3594,6 @@ dependencies = [
  "tauri-utils",
  "toml 0.9.11+spec-1.1.0",
  "walkdir",
-]
-
-[[package]]
-name = "tauri-plugin-localhost"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c8d72c024121b1a3d9268293d49a56baf01a8c785561c85d17872588b839e55"
-dependencies = [
- "http",
- "log",
- "serde",
- "serde_json",
- "tauri",
- "thiserror 2.0.18",
- "tiny_http",
 ]
 
 [[package]]
@@ -4152,6 +4138,18 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "log",
+ "once_cell",
+ "url",
+]
 
 [[package]]
 name = "url"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,4 +18,4 @@ tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tiny_http = "0.12"
-ureq = { version = "2", default-features = false }
+ureq = "2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stremio-horizon-app"
-version = "0.1.1"
+version = "0.2.0"
 description = "Desktop app for Stremio Horizon"
 authors = ["Aqu1tain"]
 edition = "2021"
@@ -15,6 +15,7 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
-tauri-plugin-localhost = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tiny_http = "0.12"
+ureq = { version = "2", default-features = false }

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -22,11 +22,18 @@ fn copy_companions_to_target() {
     let _ = std::fs::create_dir_all(&target);
 
     for name in COMPANIONS {
-        let src = binaries.join(name);
+        // On Windows, binaries have .exe extension
+        let src = if cfg!(windows) && !name.contains('.') {
+            binaries.join(format!("{name}.exe"))
+        } else {
+            binaries.join(name)
+        };
+
         if !src.exists() {
             continue;
         }
-        let _ = std::fs::copy(&src, target.join(name));
-        println!("cargo:rerun-if-changed=binaries/{name}");
+        let dst = target.join(src.file_name().unwrap());
+        let _ = std::fs::copy(&src, dst);
+        println!("cargo:rerun-if-changed={}", src.display());
     }
 }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -8,6 +8,8 @@
   },
   "permissions": [
     "core:default",
-    "opener:default"
+    "opener:default",
+    "core:window:allow-set-fullscreen",
+    "core:window:allow-is-fullscreen"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,9 +1,15 @@
+use std::io::Read;
+use std::net::TcpStream;
 use std::path::PathBuf;
 use std::process::Command;
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
 use tauri::webview::WebviewWindowBuilder;
 use tauri::{Manager, WebviewUrl};
 
 const PORT: u16 = 11480;
+const SERVICE_PORT: u16 = 11470;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -12,56 +18,232 @@ pub fn run() {
 
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
-        .plugin(tauri_plugin_localhost::Builder::new(PORT).build())
         .setup(|app| {
+            start_local_server(app);
+            spawn_streaming_service(app);
+            wait_for_service();
             create_window(app)?;
-            spawn_service(app);
             Ok(())
         })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }
 
+fn wait_for_service() {
+    let deadline = Instant::now() + Duration::from_secs(15);
+    while Instant::now() < deadline {
+        if TcpStream::connect(format!("127.0.0.1:{SERVICE_PORT}")).is_ok() {
+            println!("streaming service ready on port {SERVICE_PORT}");
+            return;
+        }
+        thread::sleep(Duration::from_millis(200));
+    }
+    eprintln!("streaming service did not start in time");
+}
+
 fn create_window(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     let url = format!("http://localhost:{PORT}");
-    WebviewWindowBuilder::new(app, "main", WebviewUrl::External(url.parse()?))
+
+    #[allow(unused_mut)]
+    let mut builder = WebviewWindowBuilder::new(app, "main", WebviewUrl::External(url.parse()?))
         .title("Stremio Horizon")
         .inner_size(1280.0, 800.0)
-        .min_inner_size(900.0, 600.0)
-        .build()?;
+        .min_inner_size(900.0, 600.0);
+
+    #[cfg(target_os = "windows")]
+    {
+        builder = builder.additional_browser_args(
+            "--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection,msWebView2EnableTrackingPrevention"
+        );
+    }
+
+    builder.build()?;
     Ok(())
 }
 
-fn spawn_service(app: &tauri::App) {
-    let name = service_name();
+// ---------------------------------------------------------------------------
+// Local HTTP server: serves frontend assets + proxies streaming API
+// ---------------------------------------------------------------------------
 
-    let Some(dir) = find_service_dir(app, &name) else {
+fn start_local_server(app: &mut tauri::App) {
+    let resolver = app.asset_resolver();
+    let (tx, rx) = mpsc::channel();
+
+    // Capture index.html bytes to detect SPA fallback
+    let fallback = resolver.get("/".to_string()).map(|a| a.bytes);
+
+    thread::spawn(move || {
+        let server = tiny_http::Server::http(format!("localhost:{PORT}"))
+            .expect("unable to bind localhost server");
+        let _ = tx.send(()); // signal ready
+
+        for request in server.incoming_requests() {
+            let path = request
+                .url()
+                .split('?')
+                .next()
+                .unwrap_or(request.url())
+                .to_string();
+
+            // Try embedded frontend asset (skip SPA fallback for non-root paths)
+            if let Some(asset) = resolver.get(path.clone()) {
+                let is_root = path == "/" || path == "/index.html";
+                let is_fallback =
+                    !is_root && fallback.as_ref() == Some(&asset.bytes);
+
+                if !is_fallback {
+                    let mut resp = tiny_http::Response::from_data(asset.bytes);
+                    if let Ok(h) = tiny_http::Header::from_bytes(
+                        b"Content-Type" as &[u8],
+                        asset.mime_type.as_bytes(),
+                    ) {
+                        resp = resp.with_header(h);
+                    }
+                    if let Some(csp) = asset.csp_header {
+                        if let Ok(h) = tiny_http::Header::from_bytes(
+                            b"Content-Security-Policy" as &[u8],
+                            csp.as_bytes(),
+                        ) {
+                            resp = resp.with_header(h);
+                        }
+                    }
+                    let _ = request.respond(resp);
+                    continue;
+                }
+            }
+
+            // Reverse-proxy to the streaming service (threaded for concurrency)
+            thread::spawn(move || proxy_to_service(request));
+        }
+    });
+
+    // Wait until the server is bound before creating the window
+    let _ = rx.recv();
+}
+
+fn proxy_to_service(mut request: tiny_http::Request) {
+    let url = format!("http://127.0.0.1:{SERVICE_PORT}{}", request.url());
+    let method = request.method().to_string();
+
+    let mut proxy = ureq::request(&method, &url);
+
+    // Forward request headers (skip hop-by-hop / origin headers)
+    for h in request.headers() {
+        let name = h.field.as_str().as_str();
+        match name.to_ascii_lowercase().as_str() {
+            "host" | "connection" | "origin" | "referer" => continue,
+            _ => proxy = proxy.set(name, h.value.as_str()),
+        }
+    }
+
+    let result = if matches!(method.as_str(), "POST" | "PUT" | "PATCH") {
+        let mut body = Vec::new();
+        let _ = request.as_reader().read_to_end(&mut body);
+        proxy.send_bytes(&body)
+    } else {
+        proxy.call()
+    };
+
+    match result {
+        Ok(resp) => forward_response(request, resp),
+        Err(ureq::Error::Status(_, resp)) => forward_response(request, resp),
+        Err(ureq::Error::Transport(e)) => {
+            let resp =
+                tiny_http::Response::from_string(format!("Service unavailable: {e}"))
+                    .with_status_code(502);
+            let _ = request.respond(resp);
+        }
+    }
+}
+
+fn forward_response(request: tiny_http::Request, resp: ureq::Response) {
+    let status = resp.status();
+    let content_len = resp
+        .header("content-length")
+        .and_then(|v| v.parse::<usize>().ok());
+
+    let mut headers = Vec::new();
+    for name in resp.headers_names() {
+        // Let tiny_http manage framing headers
+        if name.eq_ignore_ascii_case("transfer-encoding")
+            || name.eq_ignore_ascii_case("content-length")
+            || name.eq_ignore_ascii_case("connection")
+        {
+            continue;
+        }
+        if let Some(value) = resp.header(&name) {
+            if let Ok(h) = tiny_http::Header::from_bytes(name.as_bytes(), value.as_bytes()) {
+                headers.push(h);
+            }
+        }
+    }
+
+    let reader = resp.into_reader();
+    let response = tiny_http::Response::new(
+        tiny_http::StatusCode(status as u16),
+        headers,
+        reader,
+        content_len,
+        None,
+    );
+    let _ = request.respond(response);
+}
+
+// ---------------------------------------------------------------------------
+// Streaming service (stremio-runtime + server.js)
+// ---------------------------------------------------------------------------
+
+fn spawn_streaming_service(app: &tauri::App) {
+    let Some(dir) = find_binaries_dir(app) else {
+        eprintln!("stremio binaries directory not found");
         return;
     };
 
-    match Command::new(dir.join(&name)).current_dir(&dir).spawn() {
-        Ok(_) => println!("stremio-service started"),
-        Err(e) => eprintln!("stremio-service failed: {e}"),
+    let runtime = dir.join(bin_name("stremio-runtime"));
+    let server_js = dir.join("server.js");
+    let ffmpeg = dir.join(bin_name("ffmpeg"));
+    let ffprobe = dir.join(bin_name("ffprobe"));
+
+    let mut cmd = Command::new(&runtime);
+    cmd.arg(&server_js)
+        .env("NO_CORS", "1")
+        .env("FFMPEG_BIN", &ffmpeg)
+        .env("FFPROBE_BIN", &ffprobe)
+        .current_dir(&dir);
+
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
+    }
+
+    match cmd.spawn() {
+        Ok(_) => println!("server.js started from {}", dir.display()),
+        Err(e) => eprintln!("server.js failed to start: {e}"),
     }
 }
 
-fn find_service_dir(app: &tauri::App, name: &str) -> Option<PathBuf> {
+fn find_binaries_dir(app: &tauri::App) -> Option<PathBuf> {
+    // Dev mode: build.rs copies binaries next to the executable
     let exe_dir = std::env::current_exe().ok()?.parent()?.to_path_buf();
-
-    if exe_dir.join(name).exists() {
+    if exe_dir.join("server.js").exists() {
         return Some(exe_dir);
     }
 
-    app.path()
-        .resource_dir()
-        .ok()
-        .filter(|d| d.join(name).exists())
+    // Production: Tauri bundles resources under a binaries/ subdirectory
+    let resource_dir = app.path().resource_dir().ok()?;
+    let binaries_dir = resource_dir.join("binaries");
+    if binaries_dir.join("server.js").exists() {
+        return Some(binaries_dir);
+    }
+
+    None
 }
 
-fn service_name() -> &'static str {
+fn bin_name(name: &str) -> String {
     if cfg!(windows) {
-        "stremio-service.exe"
+        format!("{name}.exe")
     } else {
-        "stremio-service"
+        name.to_string()
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,3 @@
-use std::io::Read;
 use std::net::TcpStream;
 use std::path::PathBuf;
 use std::process::Command;
@@ -10,6 +9,8 @@ use tauri::{Manager, WebviewUrl};
 
 const PORT: u16 = 11480;
 const SERVICE_PORT: u16 = 11470;
+const SERVICE_TIMEOUT: Duration = Duration::from_secs(15);
+const POLL_INTERVAL: Duration = Duration::from_millis(200);
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -30,13 +31,12 @@ pub fn run() {
 }
 
 fn wait_for_service() {
-    let deadline = Instant::now() + Duration::from_secs(15);
+    let deadline = Instant::now() + SERVICE_TIMEOUT;
     while Instant::now() < deadline {
         if TcpStream::connect(format!("127.0.0.1:{SERVICE_PORT}")).is_ok() {
-            println!("streaming service ready on port {SERVICE_PORT}");
             return;
         }
-        thread::sleep(Duration::from_millis(200));
+        thread::sleep(POLL_INTERVAL);
     }
     eprintln!("streaming service did not start in time");
 }
@@ -48,7 +48,8 @@ fn create_window(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>>
     let mut builder = WebviewWindowBuilder::new(app, "main", WebviewUrl::External(url.parse()?))
         .title("Stremio Horizon")
         .inner_size(1280.0, 800.0)
-        .min_inner_size(900.0, 600.0);
+        .min_inner_size(900.0, 600.0)
+        .initialization_script(FULLSCREEN_BRIDGE);
 
     #[cfg(target_os = "windows")]
     {
@@ -61,79 +62,95 @@ fn create_window(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>>
     Ok(())
 }
 
-// ---------------------------------------------------------------------------
-// Local HTTP server: serves frontend assets + proxies streaming API
-// ---------------------------------------------------------------------------
+// WKWebView/WebView2 don't expose the Fullscreen API — bridge it to Tauri's native window API.
+const FULLSCREEN_BRIDGE: &str = r#"
+(function() {
+    const invoke = window.__TAURI_INTERNALS__?.invoke;
+    if (!invoke) return;
+
+    const setFullscreen = (value) =>
+        invoke('plugin:window|set_fullscreen', { label: 'main', value }).then(() => {
+            document._tauriFullscreen = value;
+            document.dispatchEvent(new Event('fullscreenchange'));
+        });
+
+    document._tauriFullscreen = false;
+    Element.prototype.requestFullscreen = function() { return setFullscreen(true); };
+    document.exitFullscreen = function() { return setFullscreen(false); };
+
+    Object.defineProperty(document, 'fullscreenElement', {
+        get() { return document._tauriFullscreen ? document.documentElement : null; },
+        configurable: true,
+    });
+})();
+"#;
 
 fn start_local_server(app: &mut tauri::App) {
     let resolver = app.asset_resolver();
-    let (tx, rx) = mpsc::channel();
-
-    // Capture index.html bytes to detect SPA fallback
     let fallback = resolver.get("/".to_string()).map(|a| a.bytes);
+    let (tx, rx) = mpsc::channel();
 
     thread::spawn(move || {
         let server = tiny_http::Server::http(format!("localhost:{PORT}"))
             .expect("unable to bind localhost server");
-        let _ = tx.send(()); // signal ready
+        let _ = tx.send(());
 
         for request in server.incoming_requests() {
-            let path = request
-                .url()
-                .split('?')
-                .next()
-                .unwrap_or(request.url())
-                .to_string();
+            let path = request.url().split('?').next().unwrap_or(request.url()).to_string();
 
-            // Try embedded frontend asset (skip SPA fallback for non-root paths)
-            if let Some(asset) = resolver.get(path.clone()) {
-                let is_root = path == "/" || path == "/index.html";
-                let is_fallback =
-                    !is_root && fallback.as_ref() == Some(&asset.bytes);
-
-                if !is_fallback {
-                    let mut resp = tiny_http::Response::from_data(asset.bytes);
-                    if let Ok(h) = tiny_http::Header::from_bytes(
-                        b"Content-Type" as &[u8],
-                        asset.mime_type.as_bytes(),
-                    ) {
-                        resp = resp.with_header(h);
-                    }
-                    if let Some(csp) = asset.csp_header {
-                        if let Ok(h) = tiny_http::Header::from_bytes(
-                            b"Content-Security-Policy" as &[u8],
-                            csp.as_bytes(),
-                        ) {
-                            resp = resp.with_header(h);
-                        }
-                    }
-                    let _ = request.respond(resp);
-                    continue;
-                }
+            if let Some(resp) = resolve_asset(&resolver, &path, fallback.as_deref()) {
+                let _ = request.respond(resp);
+                continue;
             }
 
-            // Reverse-proxy to the streaming service (threaded for concurrency)
             thread::spawn(move || proxy_to_service(request));
         }
     });
 
-    // Wait until the server is bound before creating the window
     let _ = rx.recv();
 }
+
+fn resolve_asset(
+    resolver: &tauri::AssetResolver<tauri::Wry>,
+    path: &str,
+    fallback: Option<&[u8]>,
+) -> Option<tiny_http::Response<std::io::Cursor<Vec<u8>>>> {
+    let asset = resolver.get(path.to_string())?;
+
+    let is_root = path == "/" || path == "/index.html";
+    if !is_root && fallback == Some(asset.bytes.as_slice()) {
+        return None;
+    }
+
+    let mut resp = tiny_http::Response::from_data(asset.bytes);
+    if let Ok(h) = header("Content-Type", &asset.mime_type) {
+        resp = resp.with_header(h);
+    }
+    if let Some(ref csp) = asset.csp_header {
+        if let Ok(h) = header("Content-Security-Policy", csp) {
+            resp = resp.with_header(h);
+        }
+    }
+    Some(resp)
+}
+
+fn header(name: &str, value: &str) -> Result<tiny_http::Header, ()> {
+    tiny_http::Header::from_bytes(name.as_bytes(), value.as_bytes())
+}
+
+const SKIP_HEADERS: &[&str] = &["host", "connection", "origin", "referer"];
 
 fn proxy_to_service(mut request: tiny_http::Request) {
     let url = format!("http://127.0.0.1:{SERVICE_PORT}{}", request.url());
     let method = request.method().to_string();
 
     let mut proxy = ureq::request(&method, &url);
-
-    // Forward request headers (skip hop-by-hop / origin headers)
     for h in request.headers() {
         let name = h.field.as_str().as_str();
-        match name.to_ascii_lowercase().as_str() {
-            "host" | "connection" | "origin" | "referer" => continue,
-            _ => proxy = proxy.set(name, h.value.as_str()),
+        if SKIP_HEADERS.iter().any(|s| s.eq_ignore_ascii_case(name)) {
+            continue;
         }
+        proxy = proxy.set(name, h.value.as_str());
     }
 
     let result = if matches!(method.as_str(), "POST" | "PUT" | "PATCH") {
@@ -145,53 +162,37 @@ fn proxy_to_service(mut request: tiny_http::Request) {
     };
 
     match result {
-        Ok(resp) => forward_response(request, resp),
-        Err(ureq::Error::Status(_, resp)) => forward_response(request, resp),
+        Ok(resp) | Err(ureq::Error::Status(_, resp)) => forward_response(request, resp),
         Err(ureq::Error::Transport(e)) => {
-            let resp =
+            let _ = request.respond(
                 tiny_http::Response::from_string(format!("Service unavailable: {e}"))
-                    .with_status_code(502);
-            let _ = request.respond(resp);
+                    .with_status_code(502),
+            );
         }
     }
 }
+
+const FRAMING_HEADERS: &[&str] = &["transfer-encoding", "content-length", "connection"];
 
 fn forward_response(request: tiny_http::Request, resp: ureq::Response) {
     let status = resp.status();
-    let content_len = resp
-        .header("content-length")
-        .and_then(|v| v.parse::<usize>().ok());
+    let content_len = resp.header("content-length").and_then(|v| v.parse().ok());
 
-    let mut headers = Vec::new();
-    for name in resp.headers_names() {
-        // Let tiny_http manage framing headers
-        if name.eq_ignore_ascii_case("transfer-encoding")
-            || name.eq_ignore_ascii_case("content-length")
-            || name.eq_ignore_ascii_case("connection")
-        {
-            continue;
-        }
-        if let Some(value) = resp.header(&name) {
-            if let Ok(h) = tiny_http::Header::from_bytes(name.as_bytes(), value.as_bytes()) {
-                headers.push(h);
-            }
-        }
-    }
+    let headers: Vec<_> = resp
+        .headers_names()
+        .iter()
+        .filter(|n| !FRAMING_HEADERS.iter().any(|f| f.eq_ignore_ascii_case(n)))
+        .filter_map(|n| resp.header(n).and_then(|v| header(n, v).ok()))
+        .collect();
 
-    let reader = resp.into_reader();
-    let response = tiny_http::Response::new(
+    let _ = request.respond(tiny_http::Response::new(
         tiny_http::StatusCode(status as u16),
         headers,
-        reader,
+        resp.into_reader(),
         content_len,
         None,
-    );
-    let _ = request.respond(response);
+    ));
 }
-
-// ---------------------------------------------------------------------------
-// Streaming service (stremio-runtime + server.js)
-// ---------------------------------------------------------------------------
 
 fn spawn_streaming_service(app: &tauri::App) {
     let Some(dir) = find_binaries_dir(app) else {
@@ -199,22 +200,17 @@ fn spawn_streaming_service(app: &tauri::App) {
         return;
     };
 
-    let runtime = dir.join(bin_name("stremio-runtime"));
-    let server_js = dir.join("server.js");
-    let ffmpeg = dir.join(bin_name("ffmpeg"));
-    let ffprobe = dir.join(bin_name("ffprobe"));
-
-    let mut cmd = Command::new(&runtime);
-    cmd.arg(&server_js)
+    let mut cmd = Command::new(dir.join(bin_name("stremio-runtime")));
+    cmd.arg(dir.join("server.js"))
         .env("NO_CORS", "1")
-        .env("FFMPEG_BIN", &ffmpeg)
-        .env("FFPROBE_BIN", &ffprobe)
+        .env("FFMPEG_BIN", dir.join(bin_name("ffmpeg")))
+        .env("FFPROBE_BIN", dir.join(bin_name("ffprobe")))
         .current_dir(&dir);
 
     #[cfg(target_os = "windows")]
     {
         use std::os::windows::process::CommandExt;
-        cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
+        cmd.creation_flags(0x0800_0000);
     }
 
     match cmd.spawn() {
@@ -224,26 +220,15 @@ fn spawn_streaming_service(app: &tauri::App) {
 }
 
 fn find_binaries_dir(app: &tauri::App) -> Option<PathBuf> {
-    // Dev mode: build.rs copies binaries next to the executable
-    let exe_dir = std::env::current_exe().ok()?.parent()?.to_path_buf();
-    if exe_dir.join("server.js").exists() {
-        return Some(exe_dir);
-    }
-
-    // Production: Tauri bundles resources under a binaries/ subdirectory
-    let resource_dir = app.path().resource_dir().ok()?;
-    let binaries_dir = resource_dir.join("binaries");
-    if binaries_dir.join("server.js").exists() {
-        return Some(binaries_dir);
-    }
-
-    None
+    [
+        std::env::current_exe().ok().and_then(|p| p.parent().map(|p| p.to_path_buf())),
+        app.path().resource_dir().ok().map(|d| d.join("binaries")),
+    ]
+    .into_iter()
+    .flatten()
+    .find(|d| d.join("server.js").exists())
 }
 
 fn bin_name(name: &str) -> String {
-    if cfg!(windows) {
-        format!("{name}.exe")
-    } else {
-        name.to_string()
-    }
+    if cfg!(windows) { format!("{name}.exe") } else { name.into() }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Stremio Horizon",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "identifier": "com.aqu1tain.stremio-horizon",
   "build": {
     "frontendDist": "../dist"


### PR DESCRIPTION
## Summary
- Enable TLS in ureq proxy (fixes "Unknown Scheme" error when streaming service redirects to HTTPS)
- Bridge the Fullscreen API to Tauri's native window API (WKWebView/WebView2 don't expose it)
- Add `core:window:allow-set-fullscreen` and `core:window:allow-is-fullscreen` permissions
- Refactor lib.rs: extract `resolve_asset`/`header` helpers, DRY `find_binaries_dir`, remove noise comments

## Test plan
- [x] Production build on macOS — app launches, frontend loads, streaming service connects
- [x] Fullscreen button works (enter + exit)
- [ ] Test on Windows (CI)
- [ ] Test on Linux (CI)