### PR TITLE
fix: clean stale stremio-service clone in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Clone stremio-service fork
         shell: bash
-        run: git clone https://github.com/Aqu1tain/stremio-service "$RUNNER_TEMP/stremio-service"
+        run: rm -rf "$RUNNER_TEMP/stremio-service" && git clone https://github.com/Aqu1tain/stremio-service "$RUNNER_TEMP/stremio-service"
 
       - name: Build stremio-service
         shell: bash


### PR DESCRIPTION
Removes existing directory before git clone to prevent failure on re-runs.