### PR TITLE
chore: bump version to 0.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
   "name": "stremio-horizon-app",
   "private": true,
-  "version": "0.2.1",
-  "type": "module",
+  "version": "0.2.2",
   "scripts": {
     "tauri": "tauri",
     "build:web": "cd ../stremio-web && pnpm run build && cp -r build ../stremio-horizon-app/dist",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3349,7 +3349,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stremio-horizon-app"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stremio-horizon-app"
-version = "0.2.1"
+version = "0.2.2"
 description = "Desktop app for Stremio Horizon"
 authors = ["Aqu1tain"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Stremio Horizon",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "identifier": "com.aqu1tain.stremio-horizon",
   "build": {
     "frontendDist": "../dist"


### PR DESCRIPTION
## Summary
- Bump version to 0.2.2
- Remove `"type": "module"` from package.json (fixes server.js CommonJS crash in local dev)

Triggers a new release build with the latest stremio-horizon web frontend, which includes the fullscreen fix for Windows.