### PR TITLE
chore: use stremio-horizon release artifact instead of building from source

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,22 +12,12 @@ jobs:
   build-web:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          repository: Aqu1tain/stremio-horizon
-          ref: development
-
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: pnpm
-
-      - run: pnpm install
-      - run: pnpm run build
+      - name: Download latest stremio-horizon release
+        run: |
+          gh release download --repo Aqu1tain/stremio-horizon --pattern 'stremio-web.zip'
+          unzip stremio-web.zip
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- CI now downloads `stremio-web.zip` from the latest stremio-horizon release instead of cloning and building from source
- Gives explicit control over which web build ships with each app release
- Faster CI builds