### PR TITLE
fix: disable hardware acceleration on Linux (EGL crash)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
         if: matrix.platform == 'ubuntu-22.04'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev libssl-dev
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev libssl-dev rpm
 
       - uses: actions/download-artifact@v4
         with:
@@ -132,6 +132,7 @@ jobs:
             src-tauri/target/${{ matrix.arch }}/release/bundle/**/*.dmg
             src-tauri/target/${{ matrix.arch }}/release/bundle/**/*.app
             src-tauri/target/${{ matrix.arch }}/release/bundle/**/*.deb
+            src-tauri/target/${{ matrix.arch }}/release/bundle/**/*.rpm
             src-tauri/target/${{ matrix.arch }}/release/bundle/**/*.AppImage
             src-tauri/target/${{ matrix.arch }}/release/bundle/**/*.msi
             src-tauri/target/${{ matrix.arch }}/release/bundle/**/*.exe

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3349,7 +3349,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stremio-horizon-app"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -3358,6 +3358,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tiny_http",
  "ureq",
+ "webkit2gtk",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,3 +19,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tiny_http = "0.12"
 ureq = "2"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+webkit2gtk = { version = "=2.0.2", features = ["v2_38"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -59,7 +59,20 @@ fn create_window(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>>
         );
     }
 
-    builder.build()?;
+    #[allow(unused_variables)]
+    let window = builder.build()?;
+
+    #[cfg(target_os = "linux")]
+    {
+        use webkit2gtk::{HardwareAccelerationPolicy, SettingsExt, WebViewExt};
+        let _ = window.with_webview(|webview| {
+            let wv = webview.inner();
+            if let Some(settings) = WebViewExt::settings(&wv) {
+                settings.set_hardware_acceleration_policy(HardwareAccelerationPolicy::Never);
+            }
+        });
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- Adds `webkit2gtk` as a Linux-only dependency (pinned to `=2.0.2` matching wry)
- Uses `with_webview` to set `HardwareAccelerationPolicy::Never` on Linux
- Fixes blank window caused by `Could not create default EGL display: EGL_BAD_PARAMETER`

Closes #15

## Test plan
- [ ] Install `.AppImage` or `.deb` from v0.2.2-rc-2 on Linux
- [ ] Verify the app renders correctly (no blank window)
- [ ] Verify Windows and macOS builds are unaffected