### PR TITLE
feat: add x64 macOS build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,10 @@ jobs:
             arch: aarch64-apple-darwin
             service-os: macos
             ext: ""
+          - platform: macos-15-intel
+            arch: x86_64-apple-darwin
+            service-os: macos
+            ext: ""
           - platform: ubuntu-22.04
             arch: x86_64-unknown-linux-gnu
             service-os: linux


### PR DESCRIPTION
Adds an Intel macOS (x86_64) build target to the release workflow using the `macos-15-intel` GitHub Actions runner. This ensures pre-M1 Mac users can run the app natively. The runner is available until August 2027, by which point Intel Mac usage should be negligible.