### PR TITLE
chore: add repo hygiene files

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,12 @@
+name: Feature request
+description: Suggest something new
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: "What would you like?"
+      description: "Describe the feature, the problem it solves, and any ideas for how it should work"
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## What
+
+<!-- What does this PR do? -->
+
+## Why
+
+<!-- Why is this change needed? -->
+
+## Testing
+
+<!-- How was this tested? -->

--- a/.github/workflows/check-upstream-web.yml
+++ b/.github/workflows/check-upstream-web.yml
@@ -1,0 +1,36 @@
+name: Check upstream stremio-web
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Compare latest release tags
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          UPSTREAM=$(gh release view --repo Stremio/stremio-web --json tagName -q .tagName)
+          FORK=$(gh release view --repo Aqu1tain/stremio-horizon --json tagName -q .tagName)
+
+          echo "Upstream stremio-web: $UPSTREAM"
+          echo "Fork stremio-horizon: $FORK"
+
+          if [ "$UPSTREAM" = "$FORK" ]; then
+            echo "Tags match, nothing to do"
+            exit 0
+          fi
+
+          EXISTING=$(gh issue list --repo ${{ github.repository }} --label upstream-update --state open --json number -q '.[0].number')
+          if [ -n "$EXISTING" ]; then
+            echo "Open issue #$EXISTING already exists, skipping"
+            exit 0
+          fi
+
+          gh issue create --repo ${{ github.repository }} \
+            --title "Upstream stremio-web updated to $UPSTREAM" \
+            --body "stremio-web released **$UPSTREAM** but stremio-horizon is on **$FORK**. Review the upstream changes and update the fork if needed." \
+            --label upstream-update

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ src-tauri/gen
 
 # Sidecar binaries (downloaded, not committed)
 src-tauri/binaries/
+
+# Nested site clone
+stremio-horizon-site/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,69 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com),
+and this project adheres to [Semantic Versioning](https://semver.org).
+
+## [Unreleased]
+
+## [0.2.2] - 2026-02-12
+
+### Fixed
+
+- Disable hardware acceleration on Linux to prevent EGL crash
+
+### Changed
+
+- Download web build from stremio-horizon release instead of building from source
+- Add RPM to Linux build artifacts
+
+## [0.2.1] - 2026-02-09
+
+### Added
+
+- Proxy external addon requests via same-origin fetch interceptor
+
+### Fixed
+
+- Resolve fullscreen bridge timing issue on WebView2
+- Preserve invoke context and exclude Tauri IPC from fetch interceptor
+- Clean stale stremio-service clone before checkout in CI
+
+## [0.2.0] - 2026-02-09
+
+### Changed
+
+- Replace localhost plugin with same-origin proxy server
+- Enable TLS for proxy, add fullscreen bridge, refactor lib.rs
+
+## [0.1.1] - 2026-02-09
+
+### Fixed
+
+- Disable DMABUF renderer on Linux to prevent EGL crash
+
+### Changed
+
+- Add Rust build cache for faster CI builds
+
+## [0.1.0] - 2026-02-09
+
+### Added
+
+- Initial Tauri desktop wrapper for Stremio Horizon
+- Stremio icon, graceful sidecar spawn, resource bundling
+- CI release workflow for macOS, Linux, and Windows
+- LICENSE and CONTRIBUTING
+
+### Fixed
+
+- Use fixed port to persist session across restarts
+- Bypass CORS for stremio-service communication
+
+[Unreleased]: https://github.com/Aqu1tain/stremio-horizon-app/compare/v0.2.2...HEAD
+[0.2.2]: https://github.com/Aqu1tain/stremio-horizon-app/compare/v0.2.1...v0.2.2
+[0.2.1]: https://github.com/Aqu1tain/stremio-horizon-app/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/Aqu1tain/stremio-horizon-app/compare/v0.1.1...v0.2.0
+[0.1.1]: https://github.com/Aqu1tain/stremio-horizon-app/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/Aqu1tain/stremio-horizon-app/releases/tag/v0.1.0


### PR DESCRIPTION
## Summary

Adds the standard GitHub scaffolding the repo was missing: a backfilled changelog (v0.1.0–v0.2.2), working issue and PR templates, a weekly workflow that checks whether upstream stremio-web has released a new version, and a gitignore entry for the nested site clone.

The empty feature_request.yml that rendered as a broken template option has been replaced with a minimal working one.

## Testing

- Verify templates render correctly on the GitHub "New issue" / "New PR" pages
- Create the `upstream-update` label, then manually trigger `check-upstream-web.yml` via workflow_dispatch to confirm it compares tags and opens an issue