### PR TITLE
feat: wire up auto-update mechanism

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
             -f tag_name=${{ github.ref_name }} \
             -f name=${{ github.ref_name }} \
             -F draft=true \
-            -F prerelease=true \
+            -F prerelease=false \
             --jq '.id')
           echo "release_id=$RELEASE_ID" >> "$GITHUB_OUTPUT"
         env:
@@ -120,6 +120,8 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           releaseId: ${{ needs.create-release.outputs.release-id }}
           args: --target ${{ matrix.arch }}
@@ -136,3 +138,12 @@ jobs:
             src-tauri/target/${{ matrix.arch }}/release/bundle/**/*.AppImage
             src-tauri/target/${{ matrix.arch }}/release/bundle/**/*.msi
             src-tauri/target/${{ matrix.arch }}/release/bundle/**/*.exe
+
+  publish-release:
+    needs: [build-tauri, create-release]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish draft release
+        run: gh api repos/${{ github.repository }}/releases/${{ needs.create-release.outputs.release-id }} -X PATCH -F draft=false
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -103,7 +103,7 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "parking",
- "polling",
+ "polling 3.11.0",
  "rustix",
  "slab",
  "windows-sys 0.61.2",
@@ -513,7 +513,7 @@ dependencies = [
  "bitflags 2.10.0",
  "core-foundation",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -920,10 +920,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
 
 [[package]]
 name = "foreign-types"
@@ -932,7 +952,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -945,6 +965,12 @@ dependencies = [
  "quote",
  "syn 2.0.114",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -1487,7 +1513,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.2",
  "tokio",
  "tower-service",
  "tracing",
@@ -1633,6 +1659,16 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "if-addrs"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b2eeee38fef3aa9b4cc5f1beea8a2444fc00e7377cafae396de3f5c2065e24"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1929,6 +1965,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
+name = "mdns-sd"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fe7c11a1eb3cfbfcf702d1601c1f5f4c102cdc8665b8a557783ef634741676e"
+dependencies = [
+ "flume",
+ "if-addrs",
+ "log",
+ "polling 2.8.0",
+ "socket2 0.5.10",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1989,6 +2038,23 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5d26952a508f321b4d3d2e80e78fc2603eaefcdf0c30783867f19586518bdc"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -2301,6 +2367,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl"
+version = "0.10.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2569,6 +2679,22 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "concurrent-queue",
+ "libc",
+ "log",
+ "pin-project-lite",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2984,6 +3110,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "schemars"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3039,6 +3174,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "321c8673b092a9a42605034a9879d73cb79101ed5fd117bc9a597b89b4e9e61a"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -3285,6 +3443,16 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
@@ -3342,6 +3510,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3351,6 +3528,8 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 name = "stremio-horizon-app"
 version = "0.2.2"
 dependencies = [
+ "mdns-sd",
+ "native-tls",
  "serde",
  "serde_json",
  "tauri",
@@ -3902,7 +4081,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.2",
  "windows-sys 0.61.2",
 ]
 
@@ -4265,6 +4444,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"
@@ -4714,6 +4899,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -4761,6 +4955,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -4822,6 +5031,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -4840,6 +5055,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4855,6 +5076,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4888,6 +5115,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4903,6 +5136,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4924,6 +5163,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -4939,6 +5184,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,6 +19,8 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tiny_http = "0.12"
 ureq = "2"
+native-tls = "0.2"
+mdns-sd = "0.11"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 webkit2gtk = { version = "=2.0.2", features = ["v2_38"] }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -10,6 +10,7 @@
     "core:default",
     "opener:default",
     "core:window:allow-set-fullscreen",
-    "core:window:allow-is-fullscreen"
+    "core:window:allow-is-fullscreen",
+    "updater:default"
   ]
 }

--- a/src-tauri/src/chromecast.rs
+++ b/src-tauri/src/chromecast.rs
@@ -1,0 +1,607 @@
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::sync::mpsc::{self, Receiver, Sender, TryRecvError};
+use std::sync::Mutex;
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+use native_tls::TlsConnector;
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Manager, State};
+
+const HEARTBEAT_NS: &str = "urn:x-cast:com.google.cast.tp.heartbeat";
+const CONNECTION_NS: &str = "urn:x-cast:com.google.cast.tp.connection";
+const RECEIVER_NS: &str = "urn:x-cast:com.google.cast.receiver";
+const STREMIO_NS: &str = "urn:x-cast:com.stremio";
+
+const SENDER_ID: &str = "sender-0";
+const RECEIVER_ID: &str = "receiver-0";
+
+const READ_TIMEOUT: Duration = Duration::from_millis(500);
+const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
+const DISCOVERY_DURATION: Duration = Duration::from_secs(5);
+
+// --- Protobuf encoding/decoding ---
+
+fn encode_varint(buf: &mut Vec<u8>, mut value: u64) {
+    loop {
+        let byte = (value & 0x7F) as u8;
+        value >>= 7;
+        if value == 0 {
+            buf.push(byte);
+            return;
+        }
+        buf.push(byte | 0x80);
+    }
+}
+
+fn decode_varint(data: &[u8], pos: usize) -> Result<(u64, usize), String> {
+    let mut result: u64 = 0;
+    let mut shift = 0;
+    let mut i = pos;
+    loop {
+        if i >= data.len() {
+            return Err("varint: unexpected end of data".into());
+        }
+        let byte = data[i];
+        result |= ((byte & 0x7F) as u64) << shift;
+        i += 1;
+        if byte & 0x80 == 0 {
+            return Ok((result, i));
+        }
+        shift += 7;
+        if shift >= 64 {
+            return Err("varint: too many bytes".into());
+        }
+    }
+}
+
+fn encode_varint_field(buf: &mut Vec<u8>, field: u32, value: u64) {
+    encode_varint(buf, ((field as u64) << 3) | 0);
+    encode_varint(buf, value);
+}
+
+fn encode_bytes_field(buf: &mut Vec<u8>, field: u32, value: &[u8]) {
+    encode_varint(buf, ((field as u64) << 3) | 2);
+    encode_varint(buf, value.len() as u64);
+    buf.extend_from_slice(value);
+}
+
+fn encode_cast_message(source: &str, dest: &str, namespace: &str, payload: &str) -> Vec<u8> {
+    let mut buf = Vec::new();
+    encode_varint_field(&mut buf, 1, 0); // protocol_version = CASTV2_1_0
+    encode_bytes_field(&mut buf, 2, source.as_bytes());
+    encode_bytes_field(&mut buf, 3, dest.as_bytes());
+    encode_bytes_field(&mut buf, 4, namespace.as_bytes());
+    encode_varint_field(&mut buf, 5, 0); // payload_type = STRING
+    encode_bytes_field(&mut buf, 6, payload.as_bytes());
+    buf
+}
+
+#[derive(Debug)]
+#[allow(dead_code)]
+struct CastMessage {
+    source_id: String,
+    destination_id: String,
+    namespace: String,
+    payload_utf8: Option<String>,
+}
+
+fn decode_cast_message(data: &[u8]) -> Result<CastMessage, String> {
+    let mut pos = 0;
+    let mut source_id = String::new();
+    let mut destination_id = String::new();
+    let mut namespace = String::new();
+    let mut payload_utf8 = None;
+
+    while pos < data.len() {
+        let (tag, new_pos) = decode_varint(data, pos)?;
+        pos = new_pos;
+        let field_num = (tag >> 3) as u32;
+        let wire_type = (tag & 0x7) as u32;
+
+        match wire_type {
+            0 => {
+                let (_, new_pos) = decode_varint(data, pos)?;
+                pos = new_pos;
+            }
+            2 => {
+                let (len, new_pos) = decode_varint(data, pos)?;
+                let end = new_pos + len as usize;
+                if end > data.len() {
+                    return Err("protobuf: data truncated".into());
+                }
+                let bytes = &data[new_pos..end];
+                match field_num {
+                    2 => source_id = String::from_utf8_lossy(bytes).into(),
+                    3 => destination_id = String::from_utf8_lossy(bytes).into(),
+                    4 => namespace = String::from_utf8_lossy(bytes).into(),
+                    6 => payload_utf8 = Some(String::from_utf8_lossy(bytes).into()),
+                    _ => {}
+                }
+                pos = end;
+            }
+            _ => return Err(format!("protobuf: unsupported wire type {wire_type}")),
+        }
+    }
+
+    Ok(CastMessage {
+        source_id,
+        destination_id,
+        namespace,
+        payload_utf8,
+    })
+}
+
+// --- Cast connection ---
+
+struct CastConnection {
+    stream: native_tls::TlsStream<TcpStream>,
+    request_id: u32,
+}
+
+impl CastConnection {
+    fn connect(host: &str, port: u16) -> Result<Self, String> {
+        let tcp = TcpStream::connect((host, port)).map_err(|e| format!("tcp connect: {e}"))?;
+        tcp.set_read_timeout(Some(READ_TIMEOUT)).ok();
+        tcp.set_nodelay(true).ok();
+
+        let connector = TlsConnector::builder()
+            .danger_accept_invalid_certs(true)
+            .build()
+            .map_err(|e| format!("tls build: {e}"))?;
+
+        let stream = connector
+            .connect(host, tcp)
+            .map_err(|e| format!("tls connect: {e}"))?;
+
+        Ok(Self {
+            stream,
+            request_id: 0,
+        })
+    }
+
+    fn next_request_id(&mut self) -> u32 {
+        self.request_id += 1;
+        self.request_id
+    }
+
+    fn send(&mut self, source: &str, dest: &str, namespace: &str, payload: &str) -> Result<(), String> {
+        let msg = encode_cast_message(source, dest, namespace, payload);
+        let len = (msg.len() as u32).to_be_bytes();
+        self.stream.write_all(&len).map_err(|e| format!("send len: {e}"))?;
+        self.stream.write_all(&msg).map_err(|e| format!("send msg: {e}"))?;
+        Ok(())
+    }
+
+    fn receive(&mut self) -> Result<Option<CastMessage>, String> {
+        let mut len_buf = [0u8; 4];
+        match self.stream.read_exact(&mut len_buf) {
+            Ok(()) => {}
+            Err(ref e) if is_timeout(e) => return Ok(None),
+            Err(e) => return Err(format!("recv len: {e}")),
+        }
+        let len = u32::from_be_bytes(len_buf) as usize;
+        let mut buf = vec![0u8; len];
+        self.stream.read_exact(&mut buf).map_err(|e| format!("recv msg: {e}"))?;
+        decode_cast_message(&buf).map(Some)
+    }
+
+    fn open_connection(&mut self, dest: &str) -> Result<(), String> {
+        let payload = r#"{"type":"CONNECT"}"#;
+        self.send(SENDER_ID, dest, CONNECTION_NS, payload)
+    }
+
+    fn close_connection(&mut self, dest: &str) -> Result<(), String> {
+        let payload = r#"{"type":"CLOSE"}"#;
+        self.send(SENDER_ID, dest, CONNECTION_NS, payload)
+    }
+
+    fn ping(&mut self) -> Result<(), String> {
+        self.send(SENDER_ID, RECEIVER_ID, HEARTBEAT_NS, r#"{"type":"PING"}"#)
+    }
+
+    fn pong(&mut self) -> Result<(), String> {
+        self.send(SENDER_ID, RECEIVER_ID, HEARTBEAT_NS, r#"{"type":"PONG"}"#)
+    }
+
+    fn launch_app(&mut self, app_id: &str) -> Result<u32, String> {
+        let req_id = self.next_request_id();
+        let payload = format!(r#"{{"type":"LAUNCH","appId":"{app_id}","requestId":{req_id}}}"#);
+        self.send(SENDER_ID, RECEIVER_ID, RECEIVER_NS, &payload)?;
+        Ok(req_id)
+    }
+
+    fn stop_app(&mut self, session_id: &str) -> Result<(), String> {
+        let req_id = self.next_request_id();
+        let payload = format!(
+            r#"{{"type":"STOP","sessionId":"{session_id}","requestId":{req_id}}}"#
+        );
+        self.send(SENDER_ID, RECEIVER_ID, RECEIVER_NS, &payload)
+    }
+
+    fn send_custom(&mut self, transport_id: &str, message: &str) -> Result<(), String> {
+        self.send(SENDER_ID, transport_id, STREMIO_NS, message)
+    }
+}
+
+fn is_timeout(e: &std::io::Error) -> bool {
+    matches!(
+        e.kind(),
+        std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+    )
+}
+
+// --- Cast session thread ---
+
+enum CastCommand {
+    Launch {
+        app_id: String,
+        reply: Sender<Result<SessionInfo, String>>,
+    },
+    Send {
+        message: String,
+        reply: Sender<Result<(), String>>,
+    },
+    Disconnect,
+}
+
+#[derive(Clone, Serialize)]
+pub struct SessionInfo {
+    session_id: String,
+    transport_id: String,
+}
+
+fn emit_event(app: &AppHandle, event: &str, payload: &str) {
+    if let Some(window) = app.get_webview_window("main") {
+        let json_str = serde_json::to_string(payload).unwrap_or_default();
+        let js = format!(
+            "window.dispatchEvent(new CustomEvent('{event}', {{ detail: JSON.parse({json_str}) }}))"
+        );
+        let _ = window.eval(&js);
+    }
+}
+
+fn emit_state(app: &AppHandle, cast_state: &str, session_state: &str) {
+    emit_event(
+        app,
+        "chromecast:state-changed",
+        &format!(r#"{{"castState":"{cast_state}","sessionState":"{session_state}"}}"#),
+    );
+}
+
+fn cast_session_loop(
+    mut conn: CastConnection,
+    cmd_rx: Receiver<CastCommand>,
+    app: AppHandle,
+    device_name: String,
+) {
+    if let Err(e) = conn.open_connection(RECEIVER_ID) {
+        eprintln!("chromecast: open connection failed: {e}");
+        return;
+    }
+
+    emit_state(&app, "NOT_CONNECTED", "NO_SESSION");
+
+    let mut session: Option<SessionInfo> = None;
+    let mut last_ping = Instant::now();
+    let mut running = true;
+
+    while running {
+        // Receive messages from the Chromecast
+        match conn.receive() {
+            Ok(Some(msg)) => {
+                handle_cast_message(&mut conn, &msg, &mut session, &app, &device_name);
+            }
+            Ok(None) => {} // timeout
+            Err(e) => {
+                eprintln!("chromecast: receive error: {e}");
+                break;
+            }
+        }
+
+        // Process commands
+        loop {
+            match cmd_rx.try_recv() {
+                Ok(CastCommand::Launch { app_id, reply }) => {
+                    let result = handle_launch(&mut conn, &app_id);
+                    if result.is_ok() {
+                        emit_state(&app, "CONNECTING", "SESSION_STARTING");
+                    }
+                    // Wait for RECEIVER_STATUS with session info
+                    let session_result = if result.is_ok() {
+                        wait_for_session(&mut conn, &mut session, &app, &device_name)
+                    } else {
+                        Err(result.unwrap_err())
+                    };
+                    let _ = reply.send(session_result);
+                }
+                Ok(CastCommand::Send { message, reply }) => {
+                    let result = if let Some(ref s) = session {
+                        conn.send_custom(&s.transport_id, &message)
+                    } else {
+                        Err("no active session".into())
+                    };
+                    let _ = reply.send(result);
+                }
+                Ok(CastCommand::Disconnect) => {
+                    if let Some(ref s) = session {
+                        let _ = conn.stop_app(&s.session_id);
+                        let _ = conn.close_connection(&s.transport_id);
+                    }
+                    let _ = conn.close_connection(RECEIVER_ID);
+                    session = None;
+                    emit_state(&app, "NOT_CONNECTED", "SESSION_ENDED");
+                    running = false;
+                }
+                Err(TryRecvError::Empty) => break,
+                Err(TryRecvError::Disconnected) => {
+                    running = false;
+                    break;
+                }
+            }
+        }
+
+        // Heartbeat
+        if last_ping.elapsed() >= HEARTBEAT_INTERVAL {
+            if conn.ping().is_err() {
+                break;
+            }
+            last_ping = Instant::now();
+        }
+    }
+
+    emit_state(&app, "NOT_CONNECTED", "SESSION_ENDED");
+}
+
+fn handle_cast_message(
+    conn: &mut CastConnection,
+    msg: &CastMessage,
+    session: &mut Option<SessionInfo>,
+    app: &AppHandle,
+    _device_name: &str,
+) {
+    let payload = match &msg.payload_utf8 {
+        Some(p) => p,
+        None => return,
+    };
+
+    match msg.namespace.as_str() {
+        HEARTBEAT_NS => {
+            if let Ok(json) = serde_json::from_str::<serde_json::Value>(payload) {
+                if json.get("type").and_then(|t| t.as_str()) == Some("PING") {
+                    let _ = conn.pong();
+                }
+            }
+        }
+        RECEIVER_NS => {
+            if let Ok(json) = serde_json::from_str::<serde_json::Value>(payload) {
+                if json.get("type").and_then(|t| t.as_str()) == Some("RECEIVER_STATUS") {
+                    if let Some(apps) = json
+                        .get("status")
+                        .and_then(|s| s.get("applications"))
+                        .and_then(|a| a.as_array())
+                    {
+                        if let Some(app_info) = apps.first() {
+                            let transport_id = app_info
+                                .get("transportId")
+                                .and_then(|t| t.as_str())
+                                .unwrap_or_default()
+                                .to_string();
+                            let session_id = app_info
+                                .get("sessionId")
+                                .and_then(|s| s.as_str())
+                                .unwrap_or_default()
+                                .to_string();
+
+                            if session.is_none() && !transport_id.is_empty() {
+                                let info = SessionInfo {
+                                    session_id,
+                                    transport_id,
+                                };
+                                *session = Some(info);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        STREMIO_NS => {
+            emit_event(app, "chromecast:message", payload);
+        }
+        _ => {}
+    }
+}
+
+fn handle_launch(conn: &mut CastConnection, app_id: &str) -> Result<u32, String> {
+    conn.launch_app(app_id)
+}
+
+fn wait_for_session(
+    conn: &mut CastConnection,
+    session: &mut Option<SessionInfo>,
+    app: &AppHandle,
+    device_name: &str,
+) -> Result<SessionInfo, String> {
+    let deadline = Instant::now() + Duration::from_secs(30);
+
+    while Instant::now() < deadline {
+        match conn.receive() {
+            Ok(Some(msg)) => {
+                handle_cast_message(conn, &msg, session, app, device_name);
+                if let Some(ref info) = session {
+                    // Connect to the app's transport
+                    conn.open_connection(&info.transport_id)?;
+                    emit_state(app, "CONNECTED", "SESSION_STARTED");
+                    return Ok(info.clone());
+                }
+            }
+            Ok(None) => continue,
+            Err(e) => return Err(e),
+        }
+    }
+
+    Err("timeout waiting for session".into())
+}
+
+// --- Tauri state ---
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct DeviceInfo {
+    pub name: String,
+    pub host: String,
+    pub port: u16,
+}
+
+pub struct CastManagerState {
+    cmd_tx: Option<Sender<CastCommand>>,
+    thread_handle: Option<JoinHandle<()>>,
+    device_name: Option<String>,
+}
+
+impl Default for CastManagerState {
+    fn default() -> Self {
+        Self {
+            cmd_tx: None,
+            thread_handle: None,
+            device_name: None,
+        }
+    }
+}
+
+pub type CastManager = Mutex<CastManagerState>;
+
+// --- Tauri commands ---
+
+#[tauri::command]
+pub fn chromecast_discover() -> Result<Vec<DeviceInfo>, String> {
+    let mdns = mdns_sd::ServiceDaemon::new().map_err(|e| format!("mdns init: {e}"))?;
+    let receiver = mdns
+        .browse("_googlecast._tcp.local.")
+        .map_err(|e| format!("mdns browse: {e}"))?;
+
+    let mut devices = Vec::new();
+    let deadline = Instant::now() + DISCOVERY_DURATION;
+
+    while Instant::now() < deadline {
+        let timeout = deadline.saturating_duration_since(Instant::now());
+        match receiver.recv_timeout(timeout) {
+            Ok(mdns_sd::ServiceEvent::ServiceResolved(info)) => {
+                let name = info
+                    .get_property_val_str("fn")
+                    .unwrap_or(info.get_fullname())
+                    .to_string();
+                if let Some(addr) = info.get_addresses().iter().next() {
+                    devices.push(DeviceInfo {
+                        name,
+                        host: addr.to_string(),
+                        port: info.get_port(),
+                    });
+                }
+            }
+            Err(_) => break,
+            _ => continue,
+        }
+    }
+
+    let _ = mdns.shutdown();
+    Ok(devices)
+}
+
+#[tauri::command]
+pub fn chromecast_connect(
+    host: String,
+    port: u16,
+    name: String,
+    app_handle: AppHandle,
+    state: State<'_, CastManager>,
+) -> Result<(), String> {
+    let mut mgr = state.lock().map_err(|e| e.to_string())?;
+
+    // Disconnect existing session
+    if let Some(tx) = mgr.cmd_tx.take() {
+        let _ = tx.send(CastCommand::Disconnect);
+    }
+    if let Some(handle) = mgr.thread_handle.take() {
+        let _ = handle.join();
+    }
+
+    let conn = CastConnection::connect(&host, port)?;
+
+    let (cmd_tx, cmd_rx) = mpsc::channel();
+    let device_name = name.clone();
+    let app = app_handle.clone();
+
+    let handle = thread::spawn(move || {
+        cast_session_loop(conn, cmd_rx, app, device_name);
+    });
+
+    mgr.cmd_tx = Some(cmd_tx);
+    mgr.thread_handle = Some(handle);
+    mgr.device_name = Some(name);
+
+    Ok(())
+}
+
+#[tauri::command]
+pub fn chromecast_launch(
+    app_id: String,
+    state: State<'_, CastManager>,
+) -> Result<SessionInfo, String> {
+    let mgr = state.lock().map_err(|e| e.to_string())?;
+    let tx = mgr.cmd_tx.as_ref().ok_or("not connected")?;
+
+    let (reply_tx, reply_rx) = mpsc::channel();
+    tx.send(CastCommand::Launch {
+        app_id,
+        reply: reply_tx,
+    })
+    .map_err(|_| "cast thread gone")?;
+
+    drop(mgr); // release lock while waiting
+    reply_rx
+        .recv_timeout(Duration::from_secs(35))
+        .map_err(|_| "launch timeout")?
+}
+
+#[tauri::command]
+pub fn chromecast_send(
+    message: String,
+    state: State<'_, CastManager>,
+) -> Result<(), String> {
+    let mgr = state.lock().map_err(|e| e.to_string())?;
+    let tx = mgr.cmd_tx.as_ref().ok_or("not connected")?;
+
+    let (reply_tx, reply_rx) = mpsc::channel();
+    tx.send(CastCommand::Send {
+        message,
+        reply: reply_tx,
+    })
+    .map_err(|_| "cast thread gone")?;
+
+    drop(mgr);
+    reply_rx
+        .recv_timeout(Duration::from_secs(5))
+        .map_err(|_| "send timeout")?
+}
+
+#[tauri::command]
+pub fn chromecast_disconnect(state: State<'_, CastManager>) -> Result<(), String> {
+    let mut mgr = state.lock().map_err(|e| e.to_string())?;
+
+    if let Some(tx) = mgr.cmd_tx.take() {
+        let _ = tx.send(CastCommand::Disconnect);
+    }
+    if let Some(handle) = mgr.thread_handle.take() {
+        let _ = handle.join();
+    }
+    mgr.device_name = None;
+
+    Ok(())
+}
+
+#[tauri::command]
+pub fn chromecast_get_device_name(state: State<'_, CastManager>) -> Result<Option<String>, String> {
+    let mgr = state.lock().map_err(|e| e.to_string())?;
+    Ok(mgr.device_name.clone())
+}

--- a/src-tauri/src/chromecast.rs
+++ b/src-tauri/src/chromecast.rs
@@ -286,17 +286,31 @@ fn cast_session_loop(
     let mut session: Option<SessionInfo> = None;
     let mut last_ping = Instant::now();
     let mut running = true;
+    let mut pending_launch: Option<(String, Sender<Result<SessionInfo, String>>, Instant)> = None;
 
     while running {
         // Receive messages from the Chromecast
+        let expected_app_id = pending_launch.as_ref().map(|(id, _, _)| id.as_str());
         match conn.receive() {
             Ok(Some(msg)) => {
-                handle_cast_message(&mut conn, &msg, &mut session, &app, &device_name);
+                handle_cast_message(&mut conn, &msg, &mut session, &app, &device_name, expected_app_id);
             }
             Ok(None) => {} // timeout
             Err(e) => {
                 eprintln!("chromecast: receive error: {e}");
                 break;
+            }
+        }
+
+        // Resolve pending launch if session arrived
+        if let (Some(ref info), Some((_, reply, _))) = (&session, pending_launch.take()) {
+            let _ = conn.open_connection(&info.transport_id);
+            emit_state(&app, "CONNECTED", "SESSION_STARTED");
+            let _ = reply.send(Ok(info.clone()));
+        } else if let Some((ref _id, _, deadline)) = pending_launch {
+            if Instant::now() >= deadline {
+                let (_, reply, _) = pending_launch.take().unwrap();
+                let _ = reply.send(Err("timeout waiting for session".into()));
             }
         }
 
@@ -307,14 +321,10 @@ fn cast_session_loop(
                     let result = handle_launch(&mut conn, &app_id);
                     if result.is_ok() {
                         emit_state(&app, "CONNECTING", "SESSION_STARTING");
-                    }
-                    // Wait for RECEIVER_STATUS with session info
-                    let session_result = if result.is_ok() {
-                        wait_for_session(&mut conn, &mut session, &app, &device_name)
+                        pending_launch = Some((app_id, reply, Instant::now() + Duration::from_secs(30)));
                     } else {
-                        Err(result.unwrap_err())
-                    };
-                    let _ = reply.send(session_result);
+                        let _ = reply.send(Err(result.unwrap_err()));
+                    }
                 }
                 Ok(CastCommand::Send { message, reply }) => {
                     let result = if let Some(ref s) = session {
@@ -360,6 +370,7 @@ fn handle_cast_message(
     session: &mut Option<SessionInfo>,
     app: &AppHandle,
     _device_name: &str,
+    expected_app_id: Option<&str>,
 ) {
     let payload = match &msg.payload_utf8 {
         Some(p) => p,
@@ -383,6 +394,16 @@ fn handle_cast_message(
                         .and_then(|a| a.as_array())
                     {
                         if let Some(app_info) = apps.first() {
+                            if let Some(expected) = expected_app_id {
+                                let running_app_id = app_info
+                                    .get("appId")
+                                    .and_then(|a| a.as_str())
+                                    .unwrap_or_default();
+                                if running_app_id != expected {
+                                    return;
+                                }
+                            }
+
                             let transport_id = app_info
                                 .get("transportId")
                                 .and_then(|t| t.as_str())
@@ -417,32 +438,6 @@ fn handle_launch(conn: &mut CastConnection, app_id: &str) -> Result<u32, String>
     conn.launch_app(app_id)
 }
 
-fn wait_for_session(
-    conn: &mut CastConnection,
-    session: &mut Option<SessionInfo>,
-    app: &AppHandle,
-    device_name: &str,
-) -> Result<SessionInfo, String> {
-    let deadline = Instant::now() + Duration::from_secs(30);
-
-    while Instant::now() < deadline {
-        match conn.receive() {
-            Ok(Some(msg)) => {
-                handle_cast_message(conn, &msg, session, app, device_name);
-                if let Some(ref info) = session {
-                    // Connect to the app's transport
-                    conn.open_connection(&info.transport_id)?;
-                    emit_state(app, "CONNECTED", "SESSION_STARTED");
-                    return Ok(info.clone());
-                }
-            }
-            Ok(None) => continue,
-            Err(e) => return Err(e),
-        }
-    }
-
-    Err("timeout waiting for session".into())
-}
 
 // --- Tauri state ---
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,11 +1,13 @@
 use std::net::TcpStream;
 use std::path::PathBuf;
 use std::process::Command;
-use std::sync::mpsc;
+use std::sync::{mpsc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 use tauri::webview::WebviewWindowBuilder;
 use tauri::{Manager, WebviewUrl};
+
+mod chromecast;
 
 const PORT: u16 = 11480;
 const SERVICE_PORT: u16 = 11470;
@@ -19,6 +21,15 @@ pub fn run() {
 
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
+        .manage(Mutex::new(chromecast::CastManagerState::default()))
+        .invoke_handler(tauri::generate_handler![
+            chromecast::chromecast_discover,
+            chromecast::chromecast_connect,
+            chromecast::chromecast_launch,
+            chromecast::chromecast_send,
+            chromecast::chromecast_disconnect,
+            chromecast::chromecast_get_device_name,
+        ])
         .setup(|app| {
             start_local_server(app);
             spawn_streaming_service(app);

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -13,7 +13,16 @@
       "csp": null
     }
   },
+  "plugins": {
+    "updater": {
+      "endpoints": [
+        "https://github.com/Aqu1tain/stremio-horizon-app/releases/latest/download/latest.json"
+      ],
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEM0OEVGNDk5NThGNDM2NDkKUldSSk52UlltZlNPeEFvbzl6dzFtMncyZlJCTy9sOGtoYVlud21GQmJEZUdJTjlxTkdCakpjcnAK"
+    }
+  },
   "bundle": {
+    "createUpdaterArtifacts": true,
     "active": true,
     "targets": "all",
     "icon": [


### PR DESCRIPTION
## Summary

Completes the auto-update wiring that was missing: enables updater artifact generation during builds, grants the webview permission to invoke updater commands, and adds a CI job to publish draft releases so the `latest.json` endpoint resolves correctly.

Closes #24