### PR TITLE
Fix: numeric pre-release for MSI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stremio-horizon-app",
   "private": true,
-  "version": "0.3.0-rc.1",
+  "version": "0.3.0-1",
   "scripts": {
     "tauri": "tauri",
     "build:web": "cd ../stremio-web && pnpm run build && cp -r build ../stremio-horizon-app/dist",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stremio-horizon-app"
-version = "0.3.0-rc.1"
+version = "0.3.0-1"
 description = "Desktop app for Stremio Horizon"
 authors = ["Aqu1tain"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Stremio Horizon",
-  "version": "0.3.0-rc.1",
+  "version": "0.3.0-1",
   "identifier": "com.aqu1tain.stremio-horizon",
   "build": {
     "frontendDist": "../dist"


### PR DESCRIPTION
MSI bundler rejects non-numeric pre-release identifiers. Changes version from 0.3.0-rc.1 to 0.3.0-1.