### PR TITLE
Release v0.3.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Download latest stremio-horizon release
         run: |
-          gh release download --repo Aqu1tain/stremio-horizon v0.1.2-rc.1 --pattern 'stremio-web.zip'
+          gh release download --repo Aqu1tain/stremio-horizon v0.1.2 --pattern 'stremio-web.zip'
           unzip stremio-web.zip
         env:
           GH_TOKEN: ${{ github.token }}
@@ -37,7 +37,7 @@ jobs:
             -f tag_name=${{ github.ref_name }} \
             -f name=${{ github.ref_name }} \
             -F draft=true \
-            -F prerelease=true \
+            -F prerelease=false \
             --jq '.id')
           echo "release_id=$RELEASE_ID" >> "$GITHUB_OUTPUT"
         env:

--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ Bundles the Stremio Horizon web UI with a [forked stremio-service](https://githu
 
 Can't find the download? Head to the [latest release](https://github.com/Aqu1tain/stremio-horizon-app/releases/latest) page directly.
 
+### macOS: app is damaged / can't be opened
+
+macOS quarantines apps downloaded outside the App Store. If you get a warning, run:
+
+```bash
+sudo xattr -rd com.apple.quarantine /Applications/Stremio\ Horizon.app
+```
+
 ## How it works
 
 Tauri serves the frontend over `localhost` and spawns `stremio-service` as a sidecar process. The forked service has CORS disabled and auto-update removed so it works seamlessly inside the app.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3659,7 +3659,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stremio-horizon-app"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "mdns-sd",
  "native-tls",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stremio-horizon-app"
-version = "0.3.0-1"
+version = "0.3.0"
 description = "Desktop app for Stremio Horizon"
 authors = ["Aqu1tain"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Stremio Horizon",
-  "version": "0.3.0-1",
+  "version": "0.3.0",
   "identifier": "com.aqu1tain.stremio-horizon",
   "build": {
     "frontendDist": "../dist"


### PR DESCRIPTION
Promote v0.3.0-rc.1 to stable v0.3.0. Updates release workflow to fetch v0.1.2 frontend and marks releases as non-prerelease.