### PR TITLE
perf: reuse connections and threads in proxy server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ src-tauri/binaries/
 
 # Nested site clone
 stremio-horizon-site/
+
+CLAUDE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Changed
+
+- Reuse TCP connections and threads in proxy server (connection pooling via ureq agents, threadpool instead of raw thread::spawn)
+
 ## [0.3.1] - 2026-03-12
 
 ### Changed

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2169,6 +2169,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "num_enum"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3669,6 +3679,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-opener",
  "tauri-plugin-updater",
+ "threadpool",
  "tiny_http",
  "ureq",
  "webkit2gtk",
@@ -4194,6 +4205,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,6 +20,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tiny_http = "0.12"
 ureq = "2"
+threadpool = "1"
 native-tls = "0.2"
 mdns-sd = "0.11"
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -183,6 +183,10 @@ fn start_local_server(app: &mut tauri::App) {
             let path = raw_url.split('?').next().unwrap_or(&raw_url);
 
             if let Some(target) = path.strip_prefix(EXT_PREFIX) {
+                if !target.starts_with("http://") && !target.starts_with("https://") {
+                    let _ = request.respond(tiny_http::Response::from_string("Bad scheme").with_status_code(400));
+                    continue;
+                }
                 let target = target.to_string();
                 let agent = ext_agent.clone();
                 ext_pool.execute(move || proxy_request(request, &target, &agent));

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 use tauri::webview::WebviewWindowBuilder;
 use tauri::{Manager, WebviewUrl};
+use threadpool::ThreadPool;
 
 mod chromecast;
 mod config;
@@ -15,6 +16,11 @@ const PORT: u16 = 11480;
 const SERVICE_PORT: u16 = 11470;
 const SERVICE_TIMEOUT: Duration = Duration::from_secs(15);
 const POLL_INTERVAL: Duration = Duration::from_millis(200);
+const POOL_SIZE: usize = 8;
+const EXT_TIMEOUT: Duration = Duration::from_secs(30);
+const EXT_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const SVC_TIMEOUT: Duration = Duration::from_secs(60);
+const SVC_CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -155,6 +161,16 @@ fn start_local_server(app: &mut tauri::App) {
     let fallback = resolver.get("/".to_string()).map(|a| a.bytes);
     let (tx, rx) = mpsc::channel();
 
+    let ext_agent = ureq::AgentBuilder::new()
+        .timeout(EXT_TIMEOUT)
+        .timeout_connect(EXT_CONNECT_TIMEOUT)
+        .build();
+    let svc_agent = ureq::AgentBuilder::new()
+        .timeout(SVC_TIMEOUT)
+        .timeout_connect(SVC_CONNECT_TIMEOUT)
+        .build();
+    let pool = ThreadPool::new(POOL_SIZE);
+
     thread::spawn(move || {
         let server = tiny_http::Server::http(format!("localhost:{PORT}"))
             .expect("unable to bind localhost server");
@@ -166,7 +182,8 @@ fn start_local_server(app: &mut tauri::App) {
 
             if let Some(target) = path.strip_prefix(EXT_PREFIX) {
                 let target = target.to_string();
-                thread::spawn(move || proxy_request(request, &target));
+                let agent = ext_agent.clone();
+                pool.execute(move || proxy_request(request, &target, &agent));
                 continue;
             }
 
@@ -176,7 +193,8 @@ fn start_local_server(app: &mut tauri::App) {
             }
 
             let service_url = format!("http://127.0.0.1:{SERVICE_PORT}{raw_url}");
-            thread::spawn(move || proxy_request(request, &service_url));
+            let agent = svc_agent.clone();
+            pool.execute(move || proxy_request(request, &service_url, &agent));
         }
     });
 
@@ -213,10 +231,10 @@ fn header(name: &str, value: &str) -> Result<tiny_http::Header, ()> {
 
 const SKIP_HEADERS: &[&str] = &["host", "connection", "origin", "referer"];
 
-fn proxy_request(mut request: tiny_http::Request, url: &str) {
+fn proxy_request(mut request: tiny_http::Request, url: &str, agent: &ureq::Agent) {
     let method = request.method().to_string();
 
-    let mut proxy = ureq::request(&method, url);
+    let mut proxy = agent.request(&method, url);
     for h in request.headers() {
         let name = h.field.as_str().as_str();
         if SKIP_HEADERS.iter().any(|s| s.eq_ignore_ascii_case(name)) {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,7 +16,8 @@ const PORT: u16 = 11480;
 const SERVICE_PORT: u16 = 11470;
 const SERVICE_TIMEOUT: Duration = Duration::from_secs(15);
 const POLL_INTERVAL: Duration = Duration::from_millis(200);
-const POOL_SIZE: usize = 8;
+const EXT_POOL_SIZE: usize = 8;
+const SVC_POOL_SIZE: usize = 4;
 const EXT_TIMEOUT: Duration = Duration::from_secs(30);
 const EXT_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 const SVC_TIMEOUT: Duration = Duration::from_secs(60);
@@ -169,7 +170,8 @@ fn start_local_server(app: &mut tauri::App) {
         .timeout(SVC_TIMEOUT)
         .timeout_connect(SVC_CONNECT_TIMEOUT)
         .build();
-    let pool = ThreadPool::new(POOL_SIZE);
+    let ext_pool = ThreadPool::new(EXT_POOL_SIZE);
+    let svc_pool = ThreadPool::new(SVC_POOL_SIZE);
 
     thread::spawn(move || {
         let server = tiny_http::Server::http(format!("localhost:{PORT}"))
@@ -183,7 +185,7 @@ fn start_local_server(app: &mut tauri::App) {
             if let Some(target) = path.strip_prefix(EXT_PREFIX) {
                 let target = target.to_string();
                 let agent = ext_agent.clone();
-                pool.execute(move || proxy_request(request, &target, &agent));
+                ext_pool.execute(move || proxy_request(request, &target, &agent));
                 continue;
             }
 
@@ -194,7 +196,7 @@ fn start_local_server(app: &mut tauri::App) {
 
             let service_url = format!("http://127.0.0.1:{SERVICE_PORT}{raw_url}");
             let agent = svc_agent.clone();
-            pool.execute(move || proxy_request(request, &service_url, &agent));
+            svc_pool.execute(move || proxy_request(request, &service_url, &agent));
         }
     });
 


### PR DESCRIPTION
Closes #33

The proxy server was creating a new TCP+TLS connection and a new OS thread for every proxied request. This adds ureq agents for connection pooling (with separate timeout profiles for external addons vs local service) and a fixed-size threadpool instead of unbounded thread::spawn.

---
## EntelligenceAI PR Summary 
 Introduces TCP connection pooling and bounded thread execution in the proxy server backend.
- Replaced `thread::spawn` with a `ThreadPool` of size 8 in `src-tauri/src/lib.rs` to limit concurrent threads
- Added two `ureq::Agent` instances: `ext_agent` (30s/10s timeouts) for external requests and `svc_agent` (60s/2s timeouts) for service requests
- Agents are passed directly to `proxy_request`, replacing the global `ureq::request` function
- Added `threadpool` crate (v1.8.1) and `num_cpus` (v1.17.0) to `Cargo.toml` and `Cargo.lock`
- Updated `CHANGELOG.md` with a new entry under `[Unreleased]`

---

## Confidence Score: 2/5 - Changes Needed

- A security vulnerability exists in the URL proxy logic: the scheme check (http/https only) is insufficient because it still permits SSRF attacks against internal/private network addresses like localhost, 127.0.0.1, 169.254.x.x (AWS metadata), and other RFC-1918 ranges.
- SSRF vulnerabilities are high-severity security issues that can expose internal services, cloud metadata endpoints, or local resources to unauthorized access from external actors.
- This requires an explicit blocklist or allowlist for destination hosts/IPs before the PR is safe to merge — a simple scheme check alone is not adequate security hardening.

<details>
<summary>Files requiring special attention</summary>

- `src-tauri/src/lib.rs`

</details>