### PR TITLE
fix(chromecast): cap message size to 8MB to prevent DoS allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
+- Cap Chromecast message size at 8MB to prevent malicious receivers triggering 4GB allocations (#35)
 - Kill stremio-service on app exit instead of leaving it running (#16)
 - Show warning banner when streaming service fails to start instead of silently continuing
 - Upstream check workflow now reads upstreamVersion from horizon package.json instead of comparing mismatched release tags

--- a/src-tauri/src/chromecast.rs
+++ b/src-tauri/src/chromecast.rs
@@ -21,6 +21,10 @@ const READ_TIMEOUT: Duration = Duration::from_millis(500);
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
 const DISCOVERY_DURATION: Duration = Duration::from_secs(5);
 
+// CASTV2 messages are typically <64KB; cap allocation to defend against a
+// malicious receiver claiming u32::MAX and triggering a 4GB allocation.
+const MAX_CAST_MESSAGE_LEN: usize = 8 * 1024 * 1024;
+
 // --- Protobuf encoding/decoding ---
 
 fn encode_varint(buf: &mut Vec<u8>, mut value: u64) {
@@ -182,6 +186,9 @@ impl CastConnection {
             Err(e) => return Err(format!("recv len: {e}")),
         }
         let len = u32::from_be_bytes(len_buf) as usize;
+        if len > MAX_CAST_MESSAGE_LEN {
+            return Err(format!("recv msg: length {len} exceeds cap {MAX_CAST_MESSAGE_LEN}"));
+        }
         let mut buf = vec![0u8; len];
         self.stream.read_exact(&mut buf).map_err(|e| format!("recv msg: {e}"))?;
         decode_cast_message(&buf).map(Some)


### PR DESCRIPTION
Addresses the most severe item in #35: \`receive()\` in \`chromecast.rs\` reads a 32-bit length prefix from the wire and immediately allocates \`vec![0u8; len]\`, so a hostile or buggy receiver claiming \`u32::MAX\` triggers a 4GB allocation attempt and crashes the app. Caps the length at 8MB before allocating — well above the typical CASTV2 message size (<64KB) but far below the OOM threshold.

The other items in #35 (mDNS daemon leaks via missing drop guard, cast thread panic = zombie state, manual JSON formatting in \`launch_app\`/\`stop_app\`) are not in this PR; they're worth their own follow-ups since each touches different code paths.