### PR TITLE
fix: Cache-Control on assets, surface config save errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
+- Cache hashed frontend assets with `immutable` headers; force revalidation only on the root entry point (#36)
+- Surface config save errors instead of silently discarding them, so settings can no longer be lost without warning (#37)
 - Cap Chromecast message size at 8MB to prevent malicious receivers triggering 4GB allocations (#35)
 - Drop guard for mDNS daemon so failed Chromecast discovery no longer leaks daemons (#35)
 - Catch panics in Chromecast session thread and emit NOT_CONNECTED state instead of zombie-ing (#35)

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -31,13 +31,11 @@ pub fn load(app: &AppHandle) -> Config {
         .unwrap_or_default()
 }
 
-pub fn save(app: &AppHandle, config: &Config) {
-    let Ok(dir) = app.path().app_config_dir() else {
-        return;
-    };
-    let _ = fs::create_dir_all(&dir);
+pub fn save(app: &AppHandle, config: &Config) -> Result<(), String> {
+    let dir = app.path().app_config_dir().map_err(|e| format!("config dir: {e}"))?;
+    fs::create_dir_all(&dir).map_err(|e| format!("create config dir {}: {e}", dir.display()))?;
     let path = dir.join(CONFIG_FILE);
-    if let Ok(json) = serde_json::to_string_pretty(config) {
-        let _ = fs::write(path, json);
-    }
+    let json = serde_json::to_string_pretty(config).map_err(|e| format!("serialize config: {e}"))?;
+    fs::write(&path, json).map_err(|e| format!("write {}: {e}", path.display()))?;
+    Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -322,6 +322,17 @@ fn resolve_asset(
             resp = resp.with_header(h);
         }
     }
+    // Frontend assets are versioned by commit hash in their path, so they're safe to
+    // cache forever. The root entry point must always be revalidated so a new build
+    // is picked up immediately.
+    let cache_control = if is_root {
+        "no-cache"
+    } else {
+        "public, max-age=31536000, immutable"
+    };
+    if let Ok(h) = header("Cache-Control", cache_control) {
+        resp = resp.with_header(h);
+    }
     Some(resp)
 }
 

--- a/src-tauri/src/updater.rs
+++ b/src-tauri/src/updater.rs
@@ -65,8 +65,11 @@ pub fn get_auto_update_enabled(app: AppHandle) -> bool {
 }
 
 #[tauri::command]
-pub fn set_auto_update_enabled(app: AppHandle, enabled: bool) {
+pub fn set_auto_update_enabled(app: AppHandle, enabled: bool) -> Result<(), String> {
     let mut cfg = config::load(&app);
     cfg.auto_update = enabled;
-    config::save(&app, &cfg);
+    config::save(&app, &cfg).map_err(|e| {
+        eprintln!("failed to persist auto_update setting: {e}");
+        e
+    })
 }


### PR DESCRIPTION
Closes #36 and #37 — both small, related enough to ship together.

Frontend assets are versioned by commit hash in their path, so the WKWebView was needlessly revalidating them on every navigation. \`resolve_asset\` now sets \`Cache-Control: public, max-age=31536000, immutable\` on hashed assets and \`no-cache\` on the root entry point so a new build is picked up immediately.

\`config::save\` was swallowing errors with \`let _ =\` on \`fs::create_dir_all\` and \`fs::write\`, so a disk-full or permissions failure would lose the user's settings without any warning. It now returns \`Result<(), String>\` with descriptive error context, and the only caller (\`set_auto_update_enabled\` in updater.rs) propagates the error to the frontend and logs it.