### PR TITLE
Release stremio-horizon-app v0.3.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Download latest stremio-horizon release
         run: |
-          gh release download --repo Aqu1tain/stremio-horizon v0.1.3 --pattern 'stremio-web.zip'
+          gh release download --repo Aqu1tain/stremio-horizon v0.1.4 --pattern 'stremio-web.zip'
           unzip stremio-web.zip
         env:
           GH_TOKEN: ${{ github.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-05-26
+
 ### Changed
 
+- Updated frontend to stremio-horizon v0.1.4
+- Update checks now keep the pending update object until the user installs it
+- Added a Tauri-only auto-update setting and manual pending-update recovery in the banner
 - Reuse TCP connections and threads in proxy server (connection pooling via ureq agents, threadpool instead of raw thread::spawn)
 
 ### Fixed
 
+- Install now uses the already-discovered update instead of randomly rechecking
+- Restart after update install was verified in a packaged macOS app
 - Cache hashed frontend assets with `immutable` headers; force revalidation only on the root entry point (#36)
 - Surface config save errors instead of silently discarding them, so settings can no longer be lost without warning (#37)
 - Cap Chromecast message size at 8MB to prevent malicious receivers triggering 4GB allocations (#35)
@@ -100,7 +107,8 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Use fixed port to persist session across restarts
 - Bypass CORS for stremio-service communication
 
-[Unreleased]: https://github.com/Aqu1tain/stremio-horizon-app/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/Aqu1tain/stremio-horizon-app/compare/v0.3.2...HEAD
+[0.3.2]: https://github.com/Aqu1tain/stremio-horizon-app/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/Aqu1tain/stremio-horizon-app/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/Aqu1tain/stremio-horizon-app/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/Aqu1tain/stremio-horizon-app/compare/v0.2.1...v0.2.2

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stremio-horizon-app",
   "private": true,
-  "version": "0.3.0-1",
+  "version": "0.3.2",
   "scripts": {
     "tauri": "tauri",
     "build:web": "cd ../stremio-web && pnpm run build && cp -r build ../stremio-horizon-app/dist",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3669,7 +3669,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stremio-horizon-app"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "mdns-sd",
  "native-tls",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stremio-horizon-app"
-version = "0.3.1"
+version = "0.3.2"
 description = "Desktop app for Stremio Horizon"
 authors = ["Aqu1tain"]
 edition = "2021"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -108,6 +108,7 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .manage(Mutex::new(chromecast::CastManagerState::default()))
+        .manage(updater::SharedUpdateState::default())
         .manage(Mutex::new(None::<ServiceProcess>))
         .invoke_handler(tauri::generate_handler![
             chromecast::chromecast_discover,
@@ -117,6 +118,8 @@ pub fn run() {
             chromecast::chromecast_disconnect,
             chromecast::chromecast_get_device_name,
             updater::install_update,
+            updater::check_for_updates_now,
+            updater::get_pending_update,
             updater::get_auto_update_enabled,
             updater::set_auto_update_enabled,
         ])

--- a/src-tauri/src/updater.rs
+++ b/src-tauri/src/updater.rs
@@ -1,16 +1,86 @@
-use tauri::{AppHandle, Manager};
-use tauri_plugin_updater::UpdaterExt;
+use std::sync::Mutex;
+use tauri::{AppHandle, Manager, State};
+use tauri_plugin_updater::{Update, UpdaterExt};
 
 use crate::config;
 
-fn emit_event(app: &AppHandle, event: &str, payload: &str) {
-    if let Some(window) = app.get_webview_window("main") {
-        let json_str = serde_json::to_string(payload).unwrap_or_default();
-        let js = format!(
-            "window.dispatchEvent(new CustomEvent('{event}', {{ detail: JSON.parse({json_str}) }}))"
-        );
-        let _ = window.eval(&js);
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateInfo {
+    version: String,
+    body: String,
+}
+
+#[derive(Default)]
+pub struct UpdateState {
+    pending: Option<PendingUpdate>,
+}
+
+struct PendingUpdate {
+    info: UpdateInfo,
+    update: Update,
+}
+
+impl From<&Update> for UpdateInfo {
+    fn from(update: &Update) -> Self {
+        Self {
+            version: update.version.clone(),
+            body: update.body.clone().unwrap_or_default(),
+        }
     }
+}
+
+pub type SharedUpdateState = Mutex<UpdateState>;
+
+fn emit_event<T: serde::Serialize>(app: &AppHandle, event: &str, payload: &T) {
+    if let Some(window) = app.get_webview_window("main") {
+        let Ok(event_json) = serde_json::to_string(event) else {
+            eprintln!("failed to serialize update event name");
+            return;
+        };
+        let Ok(payload_json) = serde_json::to_string(payload) else {
+            eprintln!("failed to serialize update event payload");
+            return;
+        };
+        let js = format!(
+            "window.dispatchEvent(new CustomEvent({event_json}, {{ detail: {payload_json} }}))"
+        );
+        if let Err(error) = window.eval(&js) {
+            eprintln!("failed to emit update event {event}: {error}");
+        }
+    }
+}
+
+async fn fetch_update(app: &AppHandle) -> Result<Option<Update>, String> {
+    let updater = match app.updater() {
+        Ok(updater) => updater,
+        Err(error) => return Err(format!("failed to initialize updater: {error}")),
+    };
+    updater
+        .check()
+        .await
+        .map_err(|error| format!("failed to check for updates: {error}"))
+}
+
+fn store_update(app: &AppHandle, update: Update) -> Result<UpdateInfo, String> {
+    let update_info = UpdateInfo::from(&update);
+
+    let update_state = app.state::<SharedUpdateState>();
+    let mut update_state = update_state
+        .lock()
+        .map_err(|error| format!("failed to store pending update state: {error}"))?;
+    update_state.pending = Some(PendingUpdate {
+        info: update_info.clone(),
+        update,
+    });
+
+    Ok(update_info)
+}
+
+async fn check_for_update(app: &AppHandle) -> Result<Option<UpdateInfo>, String> {
+    let Some(update) = fetch_update(app).await? else {
+        return Ok(None);
+    };
+    store_update(app, update).map(Some)
 }
 
 pub async fn check_for_updates(app: AppHandle) {
@@ -19,44 +89,80 @@ pub async fn check_for_updates(app: AppHandle) {
         return;
     }
 
-    let Ok(updater) = app.updater() else { return };
-    let update = match updater.check().await {
-        Ok(Some(update)) => update,
-        _ => return,
+    let update_info = match check_for_update(&app).await {
+        Ok(Some(update_info)) => update_info,
+        Ok(None) => return,
+        Err(error) => {
+            eprintln!("{error}");
+            return;
+        }
     };
 
-    let version = update.version.clone();
-    let body = update.body.clone().unwrap_or_default();
-    let payload = serde_json::json!({ "version": version, "body": body }).to_string();
-    emit_event(&app, "stremio-update-available", &payload);
+    emit_event(&app, "stremio-update-available", &update_info);
+}
+
+#[tauri::command]
+pub async fn check_for_updates_now(app: AppHandle) -> Result<Option<UpdateInfo>, String> {
+    check_for_update(&app).await
 }
 
 #[tauri::command]
 pub async fn install_update(app: AppHandle) -> Result<(), String> {
-    let updater = app.updater().map_err(|e| e.to_string())?;
-    let update = updater
-        .check()
-        .await
-        .map_err(|e| e.to_string())?
-        .ok_or("no update available")?;
+    let update = {
+        let update_state = app.state::<SharedUpdateState>();
+        let update_state = update_state
+            .lock()
+            .map_err(|error| format!("failed to read pending update state: {error}"))?;
+        update_state
+            .pending
+            .as_ref()
+            .map(|pending| pending.update.clone())
+    };
+
+    let update = match update {
+        Some(update) => update,
+        None => fetch_update(&app).await?.ok_or("no update available")?,
+    };
 
     let app_clone = app.clone();
+    let mut downloaded_total = 0usize;
     update
         .download_and_install(
             move |downloaded, total| {
+                downloaded_total = downloaded_total.saturating_add(downloaded);
                 let payload = serde_json::json!({
-                    "downloaded": downloaded,
+                    "downloaded": downloaded_total,
                     "total": total.unwrap_or(0)
-                })
-                .to_string();
+                });
                 emit_event(&app_clone, "stremio-update-progress", &payload);
             },
-            || {},
+            {
+                let app = app.clone();
+                move || {
+                    let payload = serde_json::json!({
+                        "downloaded": 1,
+                        "total": 1
+                    });
+                    emit_event(&app, "stremio-update-progress", &payload);
+                }
+            },
         )
         .await
         .map_err(|e| e.to_string())?;
 
+    if let Ok(mut update_state) = app.state::<SharedUpdateState>().lock() {
+        update_state.pending = None;
+    }
+
     app.restart();
+}
+
+#[tauri::command]
+pub fn get_pending_update(update_state: State<'_, SharedUpdateState>) -> Option<UpdateInfo> {
+    update_state
+        .lock()
+        .ok()
+        .and_then(|state| state.pending.as_ref().map(|pending| pending.info.clone()))
 }
 
 #[tauri::command]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Stremio Horizon",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "identifier": "com.aqu1tain.stremio-horizon",
   "build": {
     "frontendDist": "../dist"


### PR DESCRIPTION
## Summary
- Merge packaged updater install flow fixes into development
- Use stremio-horizon v0.1.4 for the app release
- Release stremio-horizon-app v0.3.2

## Verification
- cargo check
- git diff --check development...HEAD