### PR TITLE
Fix Windows job object bindings

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,7 +25,7 @@ native-tls = "0.2"
 mdns-sd = "0.11"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_System_JobObjects"] }
+windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_Security", "Win32_System_JobObjects"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 webkit2gtk = { version = "=2.0.2", features = ["v2_38"] }


### PR DESCRIPTION
## Summary
- Enable the Win32_Security feature for windows-sys so CreateJobObjectW is generated on Windows release builds

## Verification
- cargo check
- cargo check --target x86_64-pc-windows-msvc reached the local macOS cross-toolchain limit after resolving the missing symbol path