### PR TITLE
Fix Windows job handle null check

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -68,7 +68,7 @@ mod windows_job {
     ) -> Option<JobHandle> {
         unsafe {
             let job = CreateJobObjectW(std::ptr::null(), std::ptr::null());
-            if job == 0 {
+            if job.is_null() {
                 return None;
             }
 


### PR DESCRIPTION
## Summary
- Use pointer null checking for the Windows job object HANDLE returned by CreateJobObjectW

## Verification
- cargo check