### PR TITLE
fix(build): point build:web at ../stremio-horizon

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.3.2",
   "scripts": {
     "tauri": "tauri",
-    "build:web": "cd ../stremio-web && pnpm run build && cp -r build ../stremio-horizon-app/dist",
+    "build:web": "cd ../stremio-horizon && pnpm run build && rm -rf ../stremio-horizon-app/dist && mkdir -p ../stremio-horizon-app/dist && cp -r build/. ../stremio-horizon-app/dist/",
     "dev": "pnpm tauri dev",
     "build": "pnpm build:web && pnpm tauri build"
   },


### PR DESCRIPTION
The `build:web` script in `package.json` pointed at `../stremio-web`, which does not exist locally — the frontend actually lives at `../stremio-horizon`. The release CI workflow gets the frontend by downloading `stremio-web.zip` from a stremio-horizon release, so it was unaffected, but `pnpm build:web` silently failed for anyone running it locally.

This patch fixes the cwd target and also clears `dist/` before copying, so previous-run leftovers do not accumulate.