### PR TITLE
feat(debug): add tracing + /debug/* commands + build-stamp loader

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2007,6 +2007,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2152,6 +2161,15 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "num-conv"
@@ -3539,6 +3557,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3681,6 +3708,8 @@ dependencies = [
  "tauri-plugin-updater",
  "threadpool",
  "tiny_http",
+ "tracing",
+ "tracing-subscriber",
  "ureq",
  "webkit2gtk",
  "windows-sys 0.59.0",
@@ -4209,6 +4238,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "threadpool"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4477,6 +4515,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -4653,6 +4734,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,6 +23,8 @@ ureq = "2"
 threadpool = "1"
 native-tls = "0.2"
 mdns-sd = "0.11"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_Security", "Win32_System_JobObjects"] }

--- a/src-tauri/src/debug.rs
+++ b/src-tauri/src/debug.rs
@@ -1,0 +1,131 @@
+use std::net::{SocketAddr, TcpStream};
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, State};
+
+use crate::config;
+use crate::updater::{self, SharedUpdateState, UpdateInfo};
+
+const SERVICE_PROBE_TIMEOUT: Duration = Duration::from_millis(200);
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum BuildStamp {
+    Ok {
+        frontend_commit: String,
+        frontend_build_time: String,
+        frontend_hash: String,
+        app_commit: String,
+        app_version: String,
+    },
+    Missing {
+        reason: String,
+    },
+}
+
+#[derive(Deserialize)]
+struct RawBuildStamp {
+    frontend_commit: String,
+    frontend_build_time: String,
+    frontend_hash: String,
+    app_commit: String,
+    app_version: String,
+}
+
+static BUILD_STAMP: OnceLock<BuildStamp> = OnceLock::new();
+
+fn load_build_stamp(app: &AppHandle) -> BuildStamp {
+    let resolver = app.asset_resolver();
+    let Some(asset) = resolver.get("/build-stamp.json".to_string()) else {
+        tracing::warn!(
+            scope = "debug",
+            event = "build_stamp_missing",
+            reason = "asset not embedded"
+        );
+        return BuildStamp::Missing {
+            reason: "build-stamp.json not present in embedded assets".to_string(),
+        };
+    };
+    match serde_json::from_slice::<RawBuildStamp>(&asset.bytes) {
+        Ok(raw) => BuildStamp::Ok {
+            frontend_commit: raw.frontend_commit,
+            frontend_build_time: raw.frontend_build_time,
+            frontend_hash: raw.frontend_hash,
+            app_commit: raw.app_commit,
+            app_version: raw.app_version,
+        },
+        Err(error) => {
+            tracing::warn!(
+                scope = "debug",
+                event = "build_stamp_parse_failed",
+                %error
+            );
+            BuildStamp::Missing {
+                reason: format!("build-stamp.json parse error: {error}"),
+            }
+        }
+    }
+}
+
+#[tauri::command]
+pub fn debug_build(app: AppHandle) -> BuildStamp {
+    BUILD_STAMP
+        .get_or_init(|| load_build_stamp(&app))
+        .clone()
+}
+
+#[derive(Serialize)]
+pub struct DebugState {
+    proxy_port: u16,
+    service_port: u16,
+    service_alive: bool,
+    auto_update: bool,
+}
+
+#[tauri::command]
+pub fn debug_state(app: AppHandle) -> DebugState {
+    let addr: SocketAddr = ([127, 0, 0, 1], crate::SERVICE_PORT).into();
+    let service_alive = TcpStream::connect_timeout(&addr, SERVICE_PROBE_TIMEOUT).is_ok();
+    let auto_update = config::load(&app).auto_update;
+
+    DebugState {
+        proxy_port: crate::PORT,
+        service_port: crate::SERVICE_PORT,
+        service_alive,
+        auto_update,
+    }
+}
+
+#[derive(Serialize)]
+pub struct DebugUpdater {
+    pending: Option<UpdateInfo>,
+}
+
+#[tauri::command]
+pub fn debug_updater(state: State<'_, SharedUpdateState>) -> DebugUpdater {
+    DebugUpdater {
+        pending: updater::snapshot_pending(&state),
+    }
+}
+
+#[derive(Serialize)]
+pub struct DebugEvents {
+    recent: Vec<serde_json::Value>,
+}
+
+#[tauri::command]
+pub fn debug_events() -> DebugEvents {
+    DebugEvents { recent: Vec::new() }
+}
+
+#[derive(Serialize)]
+pub struct DebugLogs {
+    recent: Vec<serde_json::Value>,
+}
+
+#[tauri::command]
+pub fn debug_logs() -> DebugLogs {
+    DebugLogs { recent: Vec::new() }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,10 +10,11 @@ use threadpool::ThreadPool;
 
 mod chromecast;
 mod config;
+mod debug;
 mod updater;
 
-const PORT: u16 = 11480;
-const SERVICE_PORT: u16 = 11470;
+pub(crate) const PORT: u16 = 11480;
+pub(crate) const SERVICE_PORT: u16 = 11470;
 const SERVICE_TIMEOUT: Duration = Duration::from_secs(15);
 const POLL_INTERVAL: Duration = Duration::from_millis(200);
 const EXT_POOL_SIZE: usize = 8;
@@ -99,10 +100,19 @@ mod windows_job {
 
 type ServiceState = Mutex<Option<ServiceProcess>>;
 
+fn init_tracing() {
+    use tracing_subscriber::{fmt, EnvFilter};
+    let filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new("info"));
+    let _ = fmt().json().with_env_filter(filter).try_init();
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     #[cfg(target_os = "linux")]
     std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+
+    init_tracing();
 
     let app = tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
@@ -122,6 +132,11 @@ pub fn run() {
             updater::get_pending_update,
             updater::get_auto_update_enabled,
             updater::set_auto_update_enabled,
+            debug::debug_build,
+            debug::debug_state,
+            debug::debug_updater,
+            debug::debug_events,
+            debug::debug_logs,
         ])
         .setup(|app| {
             start_local_server(app);

--- a/src-tauri/src/updater.rs
+++ b/src-tauri/src/updater.rs
@@ -34,18 +34,31 @@ pub type SharedUpdateState = Mutex<UpdateState>;
 fn emit_event<T: serde::Serialize>(app: &AppHandle, event: &str, payload: &T) {
     if let Some(window) = app.get_webview_window("main") {
         let Ok(event_json) = serde_json::to_string(event) else {
-            eprintln!("failed to serialize update event name");
+            tracing::warn!(
+                scope = "updater",
+                event = "serialize_event_name_failed",
+                name = %event
+            );
             return;
         };
         let Ok(payload_json) = serde_json::to_string(payload) else {
-            eprintln!("failed to serialize update event payload");
+            tracing::warn!(
+                scope = "updater",
+                event = "serialize_event_payload_failed",
+                name = %event
+            );
             return;
         };
         let js = format!(
             "window.dispatchEvent(new CustomEvent({event_json}, {{ detail: {payload_json} }}))"
         );
         if let Err(error) = window.eval(&js) {
-            eprintln!("failed to emit update event {event}: {error}");
+            tracing::warn!(
+                scope = "updater",
+                event = "emit_event_failed",
+                name = %event,
+                %error
+            );
         }
     }
 }
@@ -93,7 +106,11 @@ pub async fn check_for_updates(app: AppHandle) {
         Ok(Some(update_info)) => update_info,
         Ok(None) => return,
         Err(error) => {
-            eprintln!("{error}");
+            tracing::error!(
+                scope = "updater",
+                event = "check_for_updates_failed",
+                %error
+            );
             return;
         }
     };
@@ -175,7 +192,18 @@ pub fn set_auto_update_enabled(app: AppHandle, enabled: bool) -> Result<(), Stri
     let mut cfg = config::load(&app);
     cfg.auto_update = enabled;
     config::save(&app, &cfg).map_err(|e| {
-        eprintln!("failed to persist auto_update setting: {e}");
+        tracing::error!(
+            scope = "updater",
+            event = "persist_auto_update_failed",
+            error = %e
+        );
         e
     })
+}
+
+pub fn snapshot_pending(state: &SharedUpdateState) -> Option<UpdateInfo> {
+    state
+        .lock()
+        .ok()
+        .and_then(|s| s.pending.as_ref().map(|pending| pending.info.clone()))
 }


### PR DESCRIPTION
Adds structured logging via `tracing` + `tracing-subscriber` (JSON to stderr) and a new `src/debug.rs` module exposing five read-only Tauri commands.

`debug_build` loads `dist/build-stamp.json` via the Tauri asset resolver and caches it in a `OnceLock`. If the asset is not embedded or fails to parse it returns a `BuildStamp::Missing { reason }` variant rather than panicking, so agents inspecting the build can distinguish OK from degraded.

`debug_state` reports the proxy/service ports, a 200 ms TCP probe against the streaming service, and the `auto_update` flag. `debug_updater` snapshots the in-memory pending update. `debug_events` and `debug_logs` return empty `recent: []` stubs; a follow-up PR fills them with ring-buffer captures.

`updater.rs`'s five `eprintln!` calls migrate to structured `tracing::warn!` / `error!` with a stable `scope = "updater"` field. No behavior change beyond the logging mechanism.

`PORT` and `SERVICE_PORT` are promoted from `const` to `pub(crate) const` so `debug.rs` can reference them; no API leak beyond the crate.