### PR TITLE
feat(debug): event/log ring buffers + redact paths in log capture

### DIFF
--- a/src-tauri/src/debug.rs
+++ b/src-tauri/src/debug.rs
@@ -1,14 +1,19 @@
+use std::collections::VecDeque;
 use std::net::{SocketAddr, TcpStream};
-use std::sync::OnceLock;
-use std::time::Duration;
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, State};
+use tracing::field::{Field, Visit};
+use tracing::{Event, Subscriber};
+use tracing_subscriber::layer::{Context, Layer};
 
 use crate::config;
 use crate::updater::{self, SharedUpdateState, UpdateInfo};
 
 const SERVICE_PROBE_TIMEOUT: Duration = Duration::from_millis(200);
+const RING_CAPACITY: usize = 200;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(tag = "status", rename_all = "snake_case")]
@@ -110,22 +115,163 @@ pub fn debug_updater(state: State<'_, SharedUpdateState>) -> DebugUpdater {
     }
 }
 
+// -------- ring buffers --------
+
+struct RingBuffer<T> {
+    items: VecDeque<T>,
+    capacity: usize,
+}
+
+impl<T> RingBuffer<T> {
+    fn new(capacity: usize) -> Self {
+        Self {
+            items: VecDeque::with_capacity(capacity),
+            capacity,
+        }
+    }
+
+    fn push(&mut self, item: T) {
+        if self.items.len() == self.capacity {
+            self.items.pop_front();
+        }
+        self.items.push_back(item);
+    }
+
+    fn snapshot(&self) -> Vec<T>
+    where
+        T: Clone,
+    {
+        self.items.iter().cloned().collect()
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct EventRecord {
+    timestamp_ms: u64,
+    name: String,
+    payload: serde_json::Value,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct LogRecord {
+    timestamp_ms: u64,
+    level: String,
+    scope: Option<String>,
+    event: Option<String>,
+    fields: serde_json::Map<String, serde_json::Value>,
+}
+
+static EVENT_RING: OnceLock<Arc<Mutex<RingBuffer<EventRecord>>>> = OnceLock::new();
+static LOG_RING: OnceLock<Arc<Mutex<RingBuffer<LogRecord>>>> = OnceLock::new();
+
+pub fn init_rings() {
+    let _ = EVENT_RING.set(Arc::new(Mutex::new(RingBuffer::new(RING_CAPACITY))));
+    let _ = LOG_RING.set(Arc::new(Mutex::new(RingBuffer::new(RING_CAPACITY))));
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+pub fn record_event<T: serde::Serialize>(name: &str, payload: &T) {
+    let payload = serde_json::to_value(payload).unwrap_or(serde_json::Value::Null);
+    let record = EventRecord {
+        timestamp_ms: now_ms(),
+        name: name.to_string(),
+        payload,
+    };
+    if let Some(ring) = EVENT_RING.get() {
+        if let Ok(mut guard) = ring.lock() {
+            guard.push(record);
+        }
+    }
+}
+
+#[derive(Default)]
+struct JsonVisitor {
+    scope: Option<String>,
+    event: Option<String>,
+    fields: serde_json::Map<String, serde_json::Value>,
+}
+
+impl JsonVisitor {
+    fn assign(&mut self, field: &Field, value: serde_json::Value) {
+        match field.name() {
+            "scope" => self.scope = value.as_str().map(String::from),
+            "event" => self.event = value.as_str().map(String::from),
+            other => {
+                self.fields.insert(other.to_string(), value);
+            }
+        }
+    }
+}
+
+impl Visit for JsonVisitor {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.assign(field, serde_json::Value::String(value.to_string()));
+    }
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.assign(field, serde_json::Value::Number(value.into()));
+    }
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.assign(field, serde_json::Value::Number(value.into()));
+    }
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.assign(field, serde_json::Value::Bool(value));
+    }
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        self.assign(field, serde_json::Value::String(format!("{value:?}")));
+    }
+}
+
+pub struct RingLayer;
+
+impl<S: Subscriber> Layer<S> for RingLayer {
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        let mut visitor = JsonVisitor::default();
+        event.record(&mut visitor);
+        let record = LogRecord {
+            timestamp_ms: now_ms(),
+            level: event.metadata().level().to_string(),
+            scope: visitor.scope,
+            event: visitor.event,
+            fields: visitor.fields,
+        };
+        if let Some(ring) = LOG_RING.get() {
+            if let Ok(mut guard) = ring.lock() {
+                guard.push(record);
+            }
+        }
+    }
+}
+
 #[derive(Serialize)]
 pub struct DebugEvents {
-    recent: Vec<serde_json::Value>,
+    recent: Vec<EventRecord>,
 }
 
 #[tauri::command]
 pub fn debug_events() -> DebugEvents {
-    DebugEvents { recent: Vec::new() }
+    let recent = EVENT_RING
+        .get()
+        .and_then(|r| r.lock().ok().map(|g| g.snapshot()))
+        .unwrap_or_default();
+    DebugEvents { recent }
 }
 
 #[derive(Serialize)]
 pub struct DebugLogs {
-    recent: Vec<serde_json::Value>,
+    recent: Vec<LogRecord>,
 }
 
 #[tauri::command]
 pub fn debug_logs() -> DebugLogs {
-    DebugLogs { recent: Vec::new() }
+    let recent = LOG_RING
+        .get()
+        .and_then(|r| r.lock().ok().map(|g| g.snapshot()))
+        .unwrap_or_default();
+    DebugLogs { recent }
 }

--- a/src-tauri/src/debug.rs
+++ b/src-tauri/src/debug.rs
@@ -197,8 +197,32 @@ struct JsonVisitor {
     fields: serde_json::Map<String, serde_json::Value>,
 }
 
+fn redact_paths(s: &str) -> String {
+    let mut out = redact_prefix(s, "/Users/", '/');
+    out = redact_prefix(&out, "/home/", '/');
+    redact_prefix(&out, "C:\\Users\\", '\\')
+}
+
+fn redact_prefix(s: &str, prefix: &str, sep: char) -> String {
+    let mut result = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(pos) = rest.find(prefix) {
+        result.push_str(&rest[..pos]);
+        rest = &rest[pos + prefix.len()..];
+        let end = rest.find(sep).unwrap_or(rest.len());
+        result.push_str("<redacted-path>");
+        rest = &rest[end..];
+    }
+    result.push_str(rest);
+    result
+}
+
 impl JsonVisitor {
     fn assign(&mut self, field: &Field, value: serde_json::Value) {
+        let value = match value {
+            serde_json::Value::String(s) => serde_json::Value::String(redact_paths(&s)),
+            other => other,
+        };
         match field.name() {
             "scope" => self.scope = value.as_str().map(String::from),
             "event" => self.event = value.as_str().map(String::from),
@@ -275,3 +299,50 @@ pub fn debug_logs() -> DebugLogs {
         .unwrap_or_default();
     DebugLogs { recent }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::redact_paths;
+
+    #[test]
+    fn redacts_macos_home() {
+        assert_eq!(
+            redact_paths("/Users/coren/Library/Application Support/foo"),
+            "<redacted-path>/Library/Application Support/foo"
+        );
+    }
+
+    #[test]
+    fn redacts_linux_home() {
+        assert_eq!(
+            redact_paths("write /home/coren/foo.bar: error"),
+            "write <redacted-path>/foo.bar: error"
+        );
+    }
+
+    #[test]
+    fn redacts_windows_home() {
+        assert_eq!(
+            redact_paths("C:\\Users\\coren\\AppData\\Local"),
+            "<redacted-path>\\AppData\\Local"
+        );
+    }
+
+    #[test]
+    fn passes_through_strings_without_prefixes() {
+        assert_eq!(redact_paths("hello world"), "hello world");
+        assert_eq!(redact_paths(""), "");
+        // Embedded /home/ substrings are intentionally over-redacted to err on
+        // the side of caution; the redactor is a conservative tap, not a parser.
+        assert_eq!(redact_paths("/not/a/home/path"), "/not/a<redacted-path>");
+    }
+
+    #[test]
+    fn redacts_multiple_paths_in_one_string() {
+        assert_eq!(
+            redact_paths("/Users/a/x and /home/b/y"),
+            "<redacted-path>/x and <redacted-path>/y"
+        );
+    }
+}
+

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -101,10 +101,15 @@ mod windows_job {
 type ServiceState = Mutex<Option<ServiceProcess>>;
 
 fn init_tracing() {
-    use tracing_subscriber::{fmt, EnvFilter};
+    use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+    debug::init_rings();
     let filter = EnvFilter::try_from_default_env()
         .unwrap_or_else(|_| EnvFilter::new("info"));
-    let _ = fmt().json().with_env_filter(filter).try_init();
+    let _ = tracing_subscriber::registry()
+        .with(filter)
+        .with(fmt::layer().json())
+        .with(debug::RingLayer)
+        .try_init();
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]

--- a/src-tauri/src/updater.rs
+++ b/src-tauri/src/updater.rs
@@ -1,8 +1,9 @@
 use std::sync::Mutex;
-use tauri::{AppHandle, Manager, State};
+use tauri::{AppHandle, Emitter, Manager, State};
 use tauri_plugin_updater::{Update, UpdaterExt};
 
 use crate::config;
+use crate::debug;
 
 #[derive(Clone, Debug, serde::Serialize)]
 pub struct UpdateInfo {
@@ -31,35 +32,23 @@ impl From<&Update> for UpdateInfo {
 
 pub type SharedUpdateState = Mutex<UpdateState>;
 
-fn emit_event<T: serde::Serialize>(app: &AppHandle, event: &str, payload: &T) {
-    if let Some(window) = app.get_webview_window("main") {
-        let Ok(event_json) = serde_json::to_string(event) else {
-            tracing::warn!(
-                scope = "updater",
-                event = "serialize_event_name_failed",
-                name = %event
-            );
-            return;
-        };
-        let Ok(payload_json) = serde_json::to_string(payload) else {
-            tracing::warn!(
-                scope = "updater",
-                event = "serialize_event_payload_failed",
-                name = %event
-            );
-            return;
-        };
-        let js = format!(
-            "window.dispatchEvent(new CustomEvent({event_json}, {{ detail: {payload_json} }}))"
+pub(crate) fn emit_event<T: serde::Serialize>(app: &AppHandle, event: &str, payload: &T) {
+    debug::record_event(event, payload);
+    let Some(window) = app.get_webview_window("main") else {
+        tracing::warn!(
+            scope = "updater",
+            event = "emit_event_no_window",
+            name = %event
         );
-        if let Err(error) = window.eval(&js) {
-            tracing::warn!(
-                scope = "updater",
-                event = "emit_event_failed",
-                name = %event,
-                %error
-            );
-        }
+        return;
+    };
+    if let Err(error) = window.emit(event, payload) {
+        tracing::warn!(
+            scope = "updater",
+            event = "emit_event_failed",
+            name = %event,
+            %error
+        );
     }
 }
 


### PR DESCRIPTION
Fills the ring-buffer stubs introduced in PR #53 and replaces the updater's `window.eval(CustomEvent)` shim with `window.emit`.

`debug.rs` gains a 200-slot `RingBuffer<T>`, two static `OnceLock<Arc<Mutex<RingBuffer>>>` instances for events and logs, an `EventRecord` / `LogRecord` shape, a `JsonVisitor` implementing `tracing::field::Visit`, and a `RingLayer` registered with the tracing subscriber. `debug_events` and `debug_logs` now return real snapshots; `record_event` is exposed for the updater to tap.

`updater.rs::emit_event` always calls `debug::record_event` first (observability tap captures even when no webview exists), then switches from `window.eval(format!(CustomEvent…))` to `window.emit(event, payload)`. Payload type signature is unchanged; serde JSON output is byte-identical to the prior `detail` field, so the existing frontend `listenTauri` handlers continue to receive the same logical event.

Adds a path redactor (`/Users/{x}/`, `/home/{x}/`, `C:\Users\{x}\`) applied to log-ring string captures only — `tracing_subscriber::fmt::layer().json()` to stderr is unaffected. Five unit tests cover macOS/Linux/Windows/no-match/multi-path-in-one-string.

Latent bugfix: the previous eval mechanism dispatched DOM `CustomEvent`s, which `listenTauri` (Tauri events) never received — install-progress updates were silently dropped in the UI. This PR fixes that.