### PR TITLE
test(rust): unit + integration tests for ring buffers and updater helpers

### DIFF
--- a/src-tauri/src/debug.rs
+++ b/src-tauri/src/debug.rs
@@ -302,7 +302,38 @@ pub fn debug_logs() -> DebugLogs {
 
 #[cfg(test)]
 mod tests {
-    use super::redact_paths;
+    use super::*;
+
+    #[test]
+    fn ring_buffer_caps_at_capacity_dropping_oldest() {
+        let mut ring: RingBuffer<i32> = RingBuffer::new(3);
+        for i in 0..6 {
+            ring.push(i);
+        }
+        assert_eq!(ring.snapshot(), vec![3, 4, 5]);
+    }
+
+    #[test]
+    fn ring_buffer_preserves_insertion_order_below_capacity() {
+        let mut ring: RingBuffer<String> = RingBuffer::new(5);
+        ring.push("a".to_string());
+        ring.push("b".to_string());
+        ring.push("c".to_string());
+        assert_eq!(ring.snapshot(), vec!["a".to_string(), "b".to_string(), "c".to_string()]);
+    }
+
+    #[test]
+    fn event_record_serializes_with_expected_fields() {
+        let record = EventRecord {
+            timestamp_ms: 1234,
+            name: "test".to_string(),
+            payload: serde_json::json!({"k": "v"}),
+        };
+        let json = serde_json::to_value(&record).unwrap();
+        assert_eq!(json["timestamp_ms"], 1234);
+        assert_eq!(json["name"], "test");
+        assert_eq!(json["payload"]["k"], "v");
+    }
 
     #[test]
     fn redacts_macos_home() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,6 +13,8 @@ mod config;
 mod debug;
 mod updater;
 
+pub use updater::{snapshot_pending, UpdateState};
+
 pub(crate) const PORT: u16 = 11480;
 pub(crate) const SERVICE_PORT: u16 = 11470;
 const SERVICE_TIMEOUT: Duration = Duration::from_secs(15);

--- a/src-tauri/tests/updater_integration.rs
+++ b/src-tauri/tests/updater_integration.rs
@@ -1,0 +1,15 @@
+//! Level B integration tests for the updater module.
+//!
+//! Scope today: assertions that exercise the public surface without requiring
+//! an `AppHandle` and without any network. Tests that need full IPC + HTTP
+//! mocking of `tauri-plugin-updater` are deferred until the updater endpoint
+//! can be redirected at runtime through our public API.
+
+use std::sync::Mutex;
+use stremio_horizon_app_lib::{snapshot_pending, UpdateState};
+
+#[test]
+fn snapshot_pending_is_none_on_default_state() {
+    let state = Mutex::new(UpdateState::default());
+    assert!(snapshot_pending(&state).is_none());
+}


### PR DESCRIPTION
Adds unit tests for the RingBuffer mechanics and EventRecord serialization in `src/debug.rs`, and a Level B integration test crate at `src-tauri/tests/updater_integration.rs` that exercises `snapshot_pending` against a freshly-constructed `UpdateState`.

Promotes `updater::{snapshot_pending, UpdateState}` to crate-public via a one-line `pub use` in `lib.rs` so the integration crate can reach them through the public API.

No HTTP or network: the fuller updater integration tests (driving `check_for_updates_now` / `install_update` against a fixture server) are deferred until `tauri-plugin-updater`'s endpoint can be redirected at runtime through a clean public API.