### PR TITLE
ci(release): make frontend version configurable via workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      frontend_version:
+        description: 'stremio-horizon release tag to bundle (e.g. v0.1.4)'
+        required: true
+        default: 'v0.1.4'
 
 permissions:
   contents: write
@@ -14,10 +20,11 @@ jobs:
     steps:
       - name: Download latest stremio-horizon release
         run: |
-          gh release download --repo Aqu1tain/stremio-horizon v0.1.4 --pattern 'stremio-web.zip'
+          gh release download --repo Aqu1tain/stremio-horizon "$FRONTEND_VERSION" --pattern 'stremio-web.zip'
           unzip stremio-web.zip
         env:
           GH_TOKEN: ${{ github.token }}
+          FRONTEND_VERSION: ${{ inputs.frontend_version || 'v0.1.4' }}
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Adds a `workflow_dispatch` trigger with a `frontend_version` input (default `v0.1.4`) and routes the existing `gh release download` call through a `$FRONTEND_VERSION` env var sourced from `${{ inputs.frontend_version || 'v0.1.4' }}`. Tag-push events still default to `v0.1.4` so the existing release behavior is unchanged; manual triggers can now override.