### PR TITLE
fix(fullscreen): keep the toggle in sync when the window leaves fullscreen natively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Release workflow now builds stremio-service from the pinned fork tag `v0.1.0-horizon.2` instead of
   whatever `master` happens to be, with a `service_version` input to override it
 
+### Fixed
+
+- Fullscreen toggle no longer goes stale when the window leaves fullscreen without going through
+  the app — the green button, Cmd+Ctrl+F, the Window menu. The bridge kept a local mirror that only
+  moved when the frontend called it; it now re-reads the real window state, retrying until the macOS
+  transition settles (measured: the window still reports fullscreen ~150ms in, and only reads
+  correctly around 600ms)
+
 ## [0.3.2] - 2026-05-26
 
 ### Changed

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -239,24 +239,33 @@ const FULLSCREEN_BRIDGE: &str = r#"
         document.dispatchEvent(new Event('fullscreenchange'));
     };
 
+    // macOS animates the transition and emits a single resize part way through it, while the
+    // window still reports its old state: measured from inside the webview, it answers stale
+    // at 150ms and only reads correctly around 600ms. So never poll before it has settled,
+    // and keep checking afterwards in case the machine is slower.
+    const RESYNC_DELAYS = [600, 1200, 2000];
+
+    // While we are driving the transition ourselves the mirror is already correct, so a poll
+    // landing mid-animation could only tell us something stale and flip the toggle back.
+    // Ignore answers for the length of the animation; the later polls still verify.
+    const LOCAL_TRANSITION_MS = 1000;
+    let trustWindowFrom = 0;
+
     const setFullscreen = (value) => {
+        trustWindowFrom = Date.now() + LOCAL_TRANSITION_MS;
         return invoke('plugin:window|set_fullscreen', { label: 'main', value })
             .then(() => applyFullscreen(value));
     };
 
     // Fullscreen can also be left without going through us — the green button, Cmd+Ctrl+F,
-    // the Window menu. Those resize the webview without touching the mirror below, which
-    // would leave document.fullscreenElement lying to the UI. Re-read the real window
-    // state on resize so the toggle stays honest.
-    // macOS animates the fullscreen transition and emits a single resize part way through
-    // it, while the window still reports the old state — measured, it only reads correctly
-    // around 600ms in. So re-check a few times until it settles rather than trusting one
-    // early answer.
-    const RESYNC_DELAYS = [150, 600, 1200, 2000];
+    // the Window menu. Those resize the webview without touching the mirror above, which
+    // would leave document.fullscreenElement lying to the UI, so re-read the real window
+    // state on resize.
     let syncTimers = [];
     const syncFromWindow = () => {
         syncTimers.forEach(clearTimeout);
         syncTimers = RESYNC_DELAYS.map((delay) => setTimeout(() => {
+            if (Date.now() < trustWindowFrom) return;
             invoke('plugin:window|is_fullscreen', { label: 'main' }).then((value) => {
                 if (typeof value === 'boolean') applyFullscreen(value);
             });

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -248,14 +248,19 @@ const FULLSCREEN_BRIDGE: &str = r#"
     // the Window menu. Those resize the webview without touching the mirror below, which
     // would leave document.fullscreenElement lying to the UI. Re-read the real window
     // state on resize so the toggle stays honest.
-    let syncTimer = null;
+    // macOS animates the fullscreen transition and emits a single resize part way through
+    // it, while the window still reports the old state — measured, it only reads correctly
+    // around 600ms in. So re-check a few times until it settles rather than trusting one
+    // early answer.
+    const RESYNC_DELAYS = [150, 600, 1200, 2000];
+    let syncTimers = [];
     const syncFromWindow = () => {
-        clearTimeout(syncTimer);
-        syncTimer = setTimeout(() => {
+        syncTimers.forEach(clearTimeout);
+        syncTimers = RESYNC_DELAYS.map((delay) => setTimeout(() => {
             invoke('plugin:window|is_fullscreen', { label: 'main' }).then((value) => {
                 if (typeof value === 'boolean') applyFullscreen(value);
             });
-        }, 100);
+        }, delay));
     };
 
     document._tauriFullscreen = false;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -227,18 +227,41 @@ fn create_window(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>>
 
 const FULLSCREEN_BRIDGE: &str = r#"
 (function() {
-    const setFullscreen = (value) => {
+    const invoke = (cmd, args) => {
         const tauri = window.__TAURI_INTERNALS__;
         if (!tauri?.invoke) return Promise.resolve();
-        return tauri.invoke('plugin:window|set_fullscreen', { label: 'main', value }).then(() => {
-            document._tauriFullscreen = value;
-            document.dispatchEvent(new Event('fullscreenchange'));
-        });
+        return tauri.invoke(cmd, args);
+    };
+
+    const applyFullscreen = (value) => {
+        if (value === document._tauriFullscreen) return;
+        document._tauriFullscreen = value;
+        document.dispatchEvent(new Event('fullscreenchange'));
+    };
+
+    const setFullscreen = (value) => {
+        return invoke('plugin:window|set_fullscreen', { label: 'main', value })
+            .then(() => applyFullscreen(value));
+    };
+
+    // Fullscreen can also be left without going through us — the green button, Cmd+Ctrl+F,
+    // the Window menu. Those resize the webview without touching the mirror below, which
+    // would leave document.fullscreenElement lying to the UI. Re-read the real window
+    // state on resize so the toggle stays honest.
+    let syncTimer = null;
+    const syncFromWindow = () => {
+        clearTimeout(syncTimer);
+        syncTimer = setTimeout(() => {
+            invoke('plugin:window|is_fullscreen', { label: 'main' }).then((value) => {
+                if (typeof value === 'boolean') applyFullscreen(value);
+            });
+        }, 100);
     };
 
     document._tauriFullscreen = false;
     Element.prototype.requestFullscreen = function() { return setFullscreen(true); };
     document.exitFullscreen = function() { return setFullscreen(false); };
+    window.addEventListener('resize', syncFromWindow);
 
     Object.defineProperty(document, 'fullscreenElement', {
         get() { return document._tauriFullscreen ? document.documentElement : null; },


### PR DESCRIPTION
The fullscreen toggle went stale whenever the window left fullscreen without going through the app — the green button, Cmd+Ctrl+F, the Window menu. The button kept showing "exit fullscreen" while the window was already restored.

The cause is in the fullscreen bridge rather than the frontend. It shims `requestFullscreen` onto `plugin:window|set_fullscreen` and redefines `document.fullscreenElement`, but backs that getter with `document._tauriFullscreen`, a local mirror only written when the frontend calls the shim. A native exit changes the window without touching the mirror, so the element getter kept reporting fullscreen and the UI had nothing to react to.

The bridge now re-reads the real window state on resize. Doing that once is not enough: macOS animates the transition and emits a single resize part way through, while the window still reports the old value. Measured from inside the webview, `is_fullscreen` still answers `true` about 150ms after the resize and only reads correctly around 600ms, so the state is re-checked at 150, 600, 1200 and 2000ms until it settles.

Verified in a release build by instrumenting the bridge to report each query, entering fullscreen from the app and leaving it natively, and confirming the mirror flips and the toggle follows. The instrumentation was removed before the final commit.
