### PR TITLE
ci: run cargo check and tests on pull requests

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,52 @@
+name: Check
+
+on:
+  push:
+    branches:
+      - development
+  pull_request:
+    branches:
+      - development
+  workflow_dispatch:
+
+concurrency:
+  group: check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  rust:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ubuntu-22.04, windows-latest]
+
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Install Linux dependencies
+        if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev libssl-dev
+
+      - name: Stub frontend dist and sidecar dir
+        shell: bash
+        run: |
+          mkdir -p dist src-tauri/binaries
+          echo '<!doctype html>' > dist/index.html
+          touch src-tauri/binaries/.gitkeep
+
+      - name: Check
+        working-directory: src-tauri
+        run: cargo check --all-targets
+
+      - name: Test
+        working-directory: src-tauri
+        run: cargo test

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,7 +22,7 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: dtolnay/rust-toolchain@stable
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Added
+
+- CI workflow running `cargo check` and `cargo test` on Linux and Windows for every pull request
+
 ## [0.3.2] - 2026-05-26
 
 ### Changed


### PR DESCRIPTION
The app repo only had a weekly upstream check and a tag-triggered release workflow, so nothing ran on pull requests and Rust breakage was only caught at release time. This adds a Check workflow that builds and tests `src-tauri` on Linux and Windows for every PR against development.

The Tauri build script needs a frontend dist and the sidecar directory to exist, so the job stubs both before running `cargo check --all-targets` and `cargo test` — no sidecar build or web bundle is downloaded, which keeps the job cheap. Verified locally against a clean copy of src-tauri with the same stubs: check and all 9 tests pass.