### PR TITLE
ci: pin stremio-service fork to v0.1.0-horizon.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,10 @@ on:
         description: 'stremio-horizon release tag to bundle (e.g. v0.1.4)'
         required: true
         default: 'v0.1.4'
+      service_version:
+        description: 'stremio-service fork tag to build (e.g. v0.1.0-horizon.2)'
+        required: true
+        default: 'v0.1.0-horizon.2'
 
 permissions:
   contents: write
@@ -109,7 +113,11 @@ jobs:
 
       - name: Clone stremio-service fork
         shell: bash
-        run: rm -rf "$RUNNER_TEMP/stremio-service" && git clone https://github.com/Aqu1tain/stremio-service "$RUNNER_TEMP/stremio-service"
+        run: |
+          rm -rf "$RUNNER_TEMP/stremio-service"
+          git clone --depth 1 --branch "$SERVICE_VERSION" https://github.com/Aqu1tain/stremio-service "$RUNNER_TEMP/stremio-service"
+        env:
+          SERVICE_VERSION: ${{ inputs.service_version || 'v0.1.0-horizon.2' }}
 
       - name: Build stremio-service
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 - CI workflow running `cargo check` and `cargo test` on Linux and Windows for every pull request
 
+### Changed
+
+- Release workflow now builds stremio-service from the pinned fork tag `v0.1.0-horizon.2` instead of
+  whatever `master` happens to be, with a `service_version` input to override it
+
 ## [0.3.2] - 2026-05-26
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -49,7 +49,15 @@ pnpm install
 
 2. Place stremio-service binaries in `src-tauri/binaries/`:
 
-Download from [stremio-service releases](https://github.com/Aqu1tain/stremio-service/releases) or build from source. You need: `stremio-service`, `server.js`, `stremio-runtime`, `ffmpeg`, `ffprobe`.
+The fork is source-only, so build it at the tag the release workflow uses:
+
+```bash
+git clone --branch v0.1.0-horizon.2 https://github.com/Aqu1tain/stremio-service
+cd stremio-service
+cargo build --release --features bundled
+```
+
+Copy `target/release/stremio-service` and everything in `resources/bin/<os>/` (`server.js`, `stremio-runtime`, `ffmpeg`, `ffprobe`) into `src-tauri/binaries/`.
 
 3. Run in development mode:
 


### PR DESCRIPTION
The release workflow cloned the stremio-service fork's default branch, so every release built whatever master happened to be at that moment. It now clones the `v0.1.0-horizon.2` tag, which is the fork synced to upstream v0.1.21 with NO_CORS forced and the built-in updater disabled, and exposes a `service_version` input to override it the same way `frontend_version` already works.

The fork publishes source-only releases with no binaries, so the README instruction to download them from the releases page was wrong. It now shows the clone-and-build steps at the same pinned tag. Verified the shallow tag clone resolves and that both fork patches are present at that commit.