### PR TITLE
chore: version 0.3.3-1 for pre-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,9 @@ on:
   workflow_dispatch:
     inputs:
       frontend_version:
-        description: 'stremio-horizon release tag to bundle (e.g. v0.1.4)'
+        description: 'stremio-horizon release tag to bundle (e.g. v0.1.5-rc.1)'
         required: true
-        default: 'v0.1.4'
+        default: 'v0.1.5-rc.1'
       service_version:
         description: 'stremio-service fork tag to build (e.g. v0.1.0-horizon.2)'
         required: true
@@ -28,7 +28,7 @@ jobs:
           unzip stremio-web.zip
         env:
           GH_TOKEN: ${{ github.token }}
-          FRONTEND_VERSION: ${{ inputs.frontend_version || 'v0.1.4' }}
+          FRONTEND_VERSION: ${{ inputs.frontend_version || 'v0.1.5-rc.1' }}
 
       - uses: actions/upload-artifact@v4
         with:
@@ -48,11 +48,12 @@ jobs:
             -f tag_name=${{ github.ref_name }} \
             -f name=${{ github.ref_name }} \
             -F draft=true \
-            -F prerelease=false \
+            -F prerelease="$PRERELEASE" \
             --jq '.id')
           echo "release_id=$RELEASE_ID" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRERELEASE: ${{ contains(github.ref_name, '-') }}
 
   build-tauri:
     needs: [build-web, create-release]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Changed
 
+- Updated frontend to stremio-horizon v0.1.5-rc.1
 - Release workflow now builds stremio-service from the pinned fork tag `v0.1.0-horizon.2` instead of
   whatever `master` happens to be, with a `service_version` input to override it
+- Release workflow marks a release as a pre-release when the tag carries a suffix, so release
+  candidates no longer publish as stable and are skipped by the updater
 
 ### Fixed
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3696,7 +3696,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stremio-horizon-app"
-version = "0.3.2"
+version = "0.3.3-1"
 dependencies = [
  "mdns-sd",
  "native-tls",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stremio-horizon-app"
-version = "0.3.2"
+version = "0.3.3-1"
 description = "Desktop app for Stremio Horizon"
 authors = ["Aqu1tain"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Stremio Horizon",
-  "version": "0.3.2",
+  "version": "0.3.3-1",
   "identifier": "com.aqu1tain.stremio-horizon",
   "build": {
     "frontendDist": "../dist"


### PR DESCRIPTION
Prepares the v0.3.3-rc.1 pre-release so the beta.39 merge, Picture-in-Picture and the hls.js recovery patch can be tested on macOS, Windows and Linux. The app version uses the numeric 0.3.3-1 form the MSI bundler requires, and the release workflow now pulls stremio-horizon v0.1.5-rc.1.

The workflow also marks a release as a pre-release whenever the tag carries a suffix. Without it a release candidate would publish as stable, and since the updater endpoint resolves through releases/latest, every installed copy would offer it as an update.