### PR TITLE
fix(proxy): keep the query string when forwarding external requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Fixed
+
+- External requests lost their query string when the proxy forwarded them, because the target URL
+  was read from the path with the query already split off. A remote streaming server then answered
+  500 to every `hlsv2/probe` call, since `mediaURL` never arrived, and playback failed with "Video
+  is not supported" on every stream. Present since the same-origin proxy landed in 0.2.1; only
+  visible when the streaming server is not on localhost, which is why the bundled service hid it
+
 ### Added
 
 - CI workflow running `cargo check` and `cargo test` on Linux and Windows for every pull request

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -338,11 +338,11 @@ fn start_local_server(app: &mut tauri::App) {
             let raw_url = request.url().to_string();
             let path = raw_url.split('?').next().unwrap_or(&raw_url);
 
-            if let Some(target) = path.strip_prefix(EXT_PREFIX) {
-                if !target.starts_with("http://") && !target.starts_with("https://") {
+            if raw_url.starts_with(EXT_PREFIX) {
+                let Some(target) = external_target(&raw_url) else {
                     let _ = request.respond(tiny_http::Response::from_string("Bad scheme").with_status_code(400));
                     continue;
-                }
+                };
                 let target = target.to_string();
                 let agent = ext_agent.clone();
                 ext_pool.execute(move || proxy_request(request, &target, &agent));
@@ -361,6 +361,17 @@ fn start_local_server(app: &mut tauri::App) {
     });
 
     let _ = rx.recv();
+}
+
+// Reads the target off the raw request URL, query string included: external URLs carry
+// theirs (the streaming server takes `?mediaURL=`, `?audioCodecs=`) and dropping it makes
+// the remote answer 500.
+fn external_target(raw_url: &str) -> Option<&str> {
+    let target = raw_url.strip_prefix(EXT_PREFIX)?;
+    if !target.starts_with("http://") && !target.starts_with("https://") {
+        return None;
+    }
+    Some(target)
 }
 
 fn resolve_asset(
@@ -536,4 +547,35 @@ fn find_binaries_dir(app: &tauri::App) -> Option<PathBuf> {
 
 fn bin_name(name: &str) -> String {
     if cfg!(windows) { format!("{name}.exe") } else { name.into() }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::external_target;
+
+    #[test]
+    fn keeps_the_query_string_of_an_external_url() {
+        let url = "/__ext__/https://stremio-server.example/hlsv2/probe?mediaURL=magnet%3Ax&audioCodecs=mp3";
+        assert_eq!(
+            external_target(url),
+            Some("https://stremio-server.example/hlsv2/probe?mediaURL=magnet%3Ax&audioCodecs=mp3")
+        );
+    }
+
+    #[test]
+    fn accepts_an_external_url_without_a_query_string() {
+        let url = "/__ext__/http://addon.example/manifest.json";
+        assert_eq!(external_target(url), Some("http://addon.example/manifest.json"));
+    }
+
+    #[test]
+    fn rejects_a_target_that_is_not_http() {
+        assert_eq!(external_target("/__ext__/file:///etc/passwd"), None);
+        assert_eq!(external_target("/__ext__/"), None);
+    }
+
+    #[test]
+    fn ignores_a_url_outside_the_external_prefix() {
+        assert_eq!(external_target("/scripts/main.js?v=1"), None);
+    }
 }


### PR DESCRIPTION
Playback failed with "Video is not supported" on every stream when the streaming server is remote. The proxy split the query off the request URL before reading the `/__ext__/` target, so it forwarded `https://server/hlsv2/probe` with no `mediaURL`, and the server answered 500 to that and to the master playlist request that follows.

Verified against the reporter's own server: probing a real media URL returns 200 directly and through the fixed proxy, and returns 500 when the query is dropped, which is exactly what the app was sending. The routing now reads the target off the raw URL, with unit tests covering the query, the bare URL, a non-http target and a path outside the prefix.

This is not new in the pre-release — it dates back to the same-origin proxy in 0.2.1. It stayed hidden because the bundled service runs on localhost, and localhost is never rewritten through the proxy.