### PR TITLE
chore: release 0.3.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,9 @@ on:
   workflow_dispatch:
     inputs:
       frontend_version:
-        description: 'stremio-horizon release tag to bundle (e.g. v0.1.5-rc.1)'
+        description: 'stremio-horizon release tag to bundle (e.g. v0.1.5)'
         required: true
-        default: 'v0.1.5-rc.1'
+        default: 'v0.1.5'
       service_version:
         description: 'stremio-service fork tag to build (e.g. v0.1.0-horizon.2)'
         required: true
@@ -28,7 +28,7 @@ jobs:
           unzip stremio-web.zip
         env:
           GH_TOKEN: ${{ github.token }}
-          FRONTEND_VERSION: ${{ inputs.frontend_version || 'v0.1.5-rc.1' }}
+          FRONTEND_VERSION: ${{ inputs.frontend_version || 'v0.1.5' }}
 
       - uses: actions/upload-artifact@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
-### Fixed
-
-- External requests lost their query string when the proxy forwarded them, because the target URL
-  was read from the path with the query already split off. A remote streaming server then answered
-  500 to every `hlsv2/probe` call, since `mediaURL` never arrived, and playback failed with "Video
-  is not supported" on every stream. Present since the same-origin proxy landed in 0.2.1; only
-  visible when the streaming server is not on localhost, which is why the bundled service hid it
+## [0.3.3] - 2026-07-31
 
 ### Added
 
@@ -21,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Changed
 
-- Updated frontend to stremio-horizon v0.1.5-rc.1
+- Updated frontend to stremio-horizon v0.1.5
 - Release workflow now builds stremio-service from the pinned fork tag `v0.1.0-horizon.2` instead of
   whatever `master` happens to be, with a `service_version` input to override it
 - Release workflow marks a release as a pre-release when the tag carries a suffix, so release
@@ -29,6 +23,11 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
+- External requests lost their query string when the proxy forwarded them, because the target URL
+  was read from the path with the query already split off. A remote streaming server then answered
+  500 to every `hlsv2/probe` call, since `mediaURL` never arrived, and playback failed with "Video
+  is not supported" on every stream. Present since the same-origin proxy landed in 0.2.1; only
+  visible when the streaming server is not on localhost, which is why the bundled service hid it
 - Fullscreen toggle no longer goes stale when the window leaves fullscreen without going through
   the app — the green button, Cmd+Ctrl+F, the Window menu. The bridge kept a local mirror that only
   moved when the frontend called it; it now re-reads the real window state, retrying until the macOS
@@ -135,7 +134,8 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Use fixed port to persist session across restarts
 - Bypass CORS for stremio-service communication
 
-[Unreleased]: https://github.com/Aqu1tain/stremio-horizon-app/compare/v0.3.2...HEAD
+[Unreleased]: https://github.com/Aqu1tain/stremio-horizon-app/compare/v0.3.3...HEAD
+[0.3.3]: https://github.com/Aqu1tain/stremio-horizon-app/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/Aqu1tain/stremio-horizon-app/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/Aqu1tain/stremio-horizon-app/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/Aqu1tain/stremio-horizon-app/compare/v0.2.2...v0.3.0

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3696,7 +3696,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stremio-horizon-app"
-version = "0.3.3-2"
+version = "0.3.3"
 dependencies = [
  "mdns-sd",
  "native-tls",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stremio-horizon-app"
-version = "0.3.3-2"
+version = "0.3.3"
 description = "Desktop app for Stremio Horizon"
 authors = ["Aqu1tain"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Stremio Horizon",
-  "version": "0.3.3-2",
+  "version": "0.3.3",
   "identifier": "com.aqu1tain.stremio-horizon",
   "build": {
     "frontendDist": "../dist"


### PR DESCRIPTION
Closes the 0.3.3 changelog section and drops the pre-release suffix from the version. The release workflow now pulls stremio-horizon v0.1.5, the final frontend release. No code change since v0.3.3-rc.2.