### PR TITLE
fix: block SSRF in external proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Fixed
+
+- Block the external HTTP proxy from reaching loopback, private, link-local, and other non-public
+  destinations, including through DNS answers and redirects (#65)
+
 ## [0.3.3] - 2026-07-31
 
 ### Added

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3711,6 +3711,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ureq",
+ "url",
  "webkit2gtk",
  "windows-sys 0.59.0",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,6 +20,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tiny_http = "0.12"
 ureq = "2"
+url = "2"
 threadpool = "1"
 native-tls = "0.2"
 mdns-sd = "0.11"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ use threadpool::ThreadPool;
 mod chromecast;
 mod config;
 mod debug;
+mod proxy_security;
 mod updater;
 
 pub use updater::{snapshot_pending, UpdateState};
@@ -321,10 +322,13 @@ fn start_local_server(app: &mut tauri::App) {
     let ext_agent = ureq::AgentBuilder::new()
         .timeout(EXT_TIMEOUT)
         .timeout_connect(EXT_CONNECT_TIMEOUT)
+        .try_proxy_from_env(false)
+        .resolver(proxy_security::PublicResolver)
         .build();
     let svc_agent = ureq::AgentBuilder::new()
         .timeout(SVC_TIMEOUT)
         .timeout_connect(SVC_CONNECT_TIMEOUT)
+        .try_proxy_from_env(false)
         .build();
     let ext_pool = ThreadPool::new(EXT_POOL_SIZE);
     let svc_pool = ThreadPool::new(SVC_POOL_SIZE);
@@ -339,13 +343,16 @@ fn start_local_server(app: &mut tauri::App) {
             let path = raw_url.split('?').next().unwrap_or(&raw_url);
 
             if raw_url.starts_with(EXT_PREFIX) {
-                let Some(target) = external_target(&raw_url) else {
-                    let _ = request.respond(tiny_http::Response::from_string("Bad scheme").with_status_code(400));
-                    continue;
+                let target = match proxy_security::external_target(&raw_url, EXT_PREFIX) {
+                    Ok(target) => target.to_string(),
+                    Err(_) => {
+                        respond_invalid_external_target(request);
+                        continue;
+                    }
                 };
-                let target = target.to_string();
                 let agent = ext_agent.clone();
-                ext_pool.execute(move || proxy_request(request, &target, &agent));
+                ext_pool
+                    .execute(move || proxy_request(request, &target, &agent, ProxyScope::External));
                 continue;
             }
 
@@ -356,22 +363,19 @@ fn start_local_server(app: &mut tauri::App) {
 
             let service_url = format!("http://127.0.0.1:{SERVICE_PORT}{raw_url}");
             let agent = svc_agent.clone();
-            svc_pool.execute(move || proxy_request(request, &service_url, &agent));
+            svc_pool
+                .execute(move || proxy_request(request, &service_url, &agent, ProxyScope::Service));
         }
     });
 
     let _ = rx.recv();
 }
 
-// Reads the target off the raw request URL, query string included: external URLs carry
-// theirs (the streaming server takes `?mediaURL=`, `?audioCodecs=`) and dropping it makes
-// the remote answer 500.
-fn external_target(raw_url: &str) -> Option<&str> {
-    let target = raw_url.strip_prefix(EXT_PREFIX)?;
-    if !target.starts_with("http://") && !target.starts_with("https://") {
-        return None;
-    }
-    Some(target)
+fn respond_invalid_external_target(request: tiny_http::Request) {
+    let _ = request.respond(
+        tiny_http::Response::from_string("Invalid or blocked external target")
+            .with_status_code(400),
+    );
 }
 
 fn resolve_asset(
@@ -415,7 +419,18 @@ fn header(name: &str, value: &str) -> Result<tiny_http::Header, ()> {
 
 const SKIP_HEADERS: &[&str] = &["host", "connection", "origin", "referer"];
 
-fn proxy_request(mut request: tiny_http::Request, url: &str, agent: &ureq::Agent) {
+#[derive(Clone, Copy)]
+enum ProxyScope {
+    External,
+    Service,
+}
+
+fn proxy_request(
+    mut request: tiny_http::Request,
+    url: &str,
+    agent: &ureq::Agent,
+    scope: ProxyScope,
+) {
     let method = request.method().to_string();
 
     let mut proxy = agent.request(&method, url);
@@ -437,10 +452,15 @@ fn proxy_request(mut request: tiny_http::Request, url: &str, agent: &ureq::Agent
 
     match result {
         Ok(resp) | Err(ureq::Error::Status(_, resp)) => forward_response(request, resp),
-        Err(ureq::Error::Transport(e)) => {
+        Err(ureq::Error::Transport(e))
+            if matches!(scope, ProxyScope::External)
+                && proxy_security::is_blocked_destination_error(&e) =>
+        {
+            respond_invalid_external_target(request);
+        }
+        Err(ureq::Error::Transport(_)) => {
             let _ = request.respond(
-                tiny_http::Response::from_string(format!("Service unavailable: {e}"))
-                    .with_status_code(502),
+                tiny_http::Response::from_string("Service unavailable").with_status_code(502),
             );
         }
     }
@@ -547,35 +567,4 @@ fn find_binaries_dir(app: &tauri::App) -> Option<PathBuf> {
 
 fn bin_name(name: &str) -> String {
     if cfg!(windows) { format!("{name}.exe") } else { name.into() }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::external_target;
-
-    #[test]
-    fn keeps_the_query_string_of_an_external_url() {
-        let url = "/__ext__/https://stremio-server.example/hlsv2/probe?mediaURL=magnet%3Ax&audioCodecs=mp3";
-        assert_eq!(
-            external_target(url),
-            Some("https://stremio-server.example/hlsv2/probe?mediaURL=magnet%3Ax&audioCodecs=mp3")
-        );
-    }
-
-    #[test]
-    fn accepts_an_external_url_without_a_query_string() {
-        let url = "/__ext__/http://addon.example/manifest.json";
-        assert_eq!(external_target(url), Some("http://addon.example/manifest.json"));
-    }
-
-    #[test]
-    fn rejects_a_target_that_is_not_http() {
-        assert_eq!(external_target("/__ext__/file:///etc/passwd"), None);
-        assert_eq!(external_target("/__ext__/"), None);
-    }
-
-    #[test]
-    fn ignores_a_url_outside_the_external_prefix() {
-        assert_eq!(external_target("/scripts/main.js?v=1"), None);
-    }
 }

--- a/src-tauri/src/proxy_security.rs
+++ b/src-tauri/src/proxy_security.rs
@@ -1,0 +1,331 @@
+use std::error::Error as _;
+use std::io;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, ToSocketAddrs};
+
+use url::{Host, Url};
+
+const BLOCKED_DESTINATION_MESSAGE: &str = "external proxy destination is not public";
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum ExternalTargetError {
+    Invalid,
+    Blocked,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct PublicResolver;
+
+impl ureq::Resolver for PublicResolver {
+    fn resolve(&self, netloc: &str) -> io::Result<Vec<SocketAddr>> {
+        let addresses = netloc.to_socket_addrs()?.collect::<Vec<_>>();
+        validate_resolved_addresses(addresses)
+    }
+}
+
+pub fn external_target(raw_url: &str, prefix: &str) -> Result<Url, ExternalTargetError> {
+    let target = raw_url
+        .strip_prefix(prefix)
+        .ok_or(ExternalTargetError::Invalid)?;
+    let target = Url::parse(target).map_err(|_| ExternalTargetError::Invalid)?;
+    validate_url(&target)?;
+    Ok(target)
+}
+
+fn validate_url(target: &Url) -> Result<(), ExternalTargetError> {
+    if !matches!(target.scheme(), "http" | "https")
+        || target.host().is_none()
+        || !target.username().is_empty()
+        || target.password().is_some()
+    {
+        return Err(ExternalTargetError::Invalid);
+    }
+
+    match target.host().expect("host checked above") {
+        Host::Domain(domain) if is_localhost_name(domain) => Err(ExternalTargetError::Blocked),
+        Host::Ipv4(address) if !is_public_ipv4(address) => Err(ExternalTargetError::Blocked),
+        Host::Ipv6(address) if !is_public_ipv6(address) => Err(ExternalTargetError::Blocked),
+        _ => Ok(()),
+    }
+}
+
+fn is_localhost_name(host: &str) -> bool {
+    let host = host.trim_end_matches('.');
+    host.eq_ignore_ascii_case("localhost") || host.to_ascii_lowercase().ends_with(".localhost")
+}
+
+fn validate_resolved_addresses(addresses: Vec<SocketAddr>) -> io::Result<Vec<SocketAddr>> {
+    if addresses.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "external proxy destination did not resolve",
+        ));
+    }
+
+    if addresses.iter().any(|address| !is_public_ip(address.ip())) {
+        return Err(blocked_destination_error());
+    }
+
+    Ok(addresses)
+}
+
+fn blocked_destination_error() -> io::Error {
+    io::Error::new(io::ErrorKind::PermissionDenied, BLOCKED_DESTINATION_MESSAGE)
+}
+
+pub fn is_blocked_destination_error(error: &ureq::Transport) -> bool {
+    error.kind() == ureq::ErrorKind::Dns
+        && error
+            .source()
+            .and_then(|source| source.downcast_ref::<io::Error>())
+            .is_some_and(|source| source.kind() == io::ErrorKind::PermissionDenied)
+}
+
+fn is_public_ip(address: IpAddr) -> bool {
+    match address {
+        IpAddr::V4(address) => is_public_ipv4(address),
+        IpAddr::V6(address) => is_public_ipv6(address),
+    }
+}
+
+fn is_public_ipv4(address: Ipv4Addr) -> bool {
+    let [first, second, third, _] = address.octets();
+
+    !matches!(
+        (first, second, third),
+        (0, _, _)
+            | (10, _, _)
+            | (100, 64..=127, _)
+            | (127, _, _)
+            | (169, 254, _)
+            | (172, 16..=31, _)
+            | (192, 0, 0)
+            | (192, 0, 2)
+            | (192, 88, 99)
+            | (192, 168, _)
+            | (198, 18..=19, _)
+            | (198, 51, 100)
+            | (203, 0, 113)
+            | (224..=255, _, _)
+    )
+}
+
+fn is_public_ipv6(address: Ipv6Addr) -> bool {
+    if let Some(mapped) = address.to_ipv4() {
+        return is_public_ipv4(mapped);
+    }
+
+    let segments = address.segments();
+    let first = segments[0];
+
+    if address.is_unspecified()
+        || address.is_loopback()
+        || address.is_multicast()
+        || first & 0xfe00 == 0xfc00
+        || first & 0xffc0 == 0xfe80
+        || first & 0xffc0 == 0xfec0
+    {
+        return false;
+    }
+
+    // IETF special-purpose, documentation, benchmarking, and local translation ranges.
+    if (first == 0x0100 && segments[1..4] == [0, 0, 0])
+        || (first == 0x0064 && segments[1] == 0xff9b && segments[2] == 1)
+        || (first == 0x2001 && segments[1] <= 0x01ff)
+        || (first == 0x2001 && segments[1] == 0x0db8)
+        || (first == 0x3fff && segments[1] < 0x1000)
+        || first == 0x5f00
+    {
+        return false;
+    }
+
+    // Validate IPv4 destinations embedded in well-known transition prefixes.
+    if first == 0x0064 && segments[1] == 0xff9b && segments[2..6] == [0, 0, 0, 0] {
+        return is_public_ipv4(Ipv4Addr::new(
+            (segments[6] >> 8) as u8,
+            segments[6] as u8,
+            (segments[7] >> 8) as u8,
+            segments[7] as u8,
+        ));
+    }
+    if first == 0x2002 {
+        return is_public_ipv4(Ipv4Addr::new(
+            (segments[1] >> 8) as u8,
+            segments[1] as u8,
+            (segments[2] >> 8) as u8,
+            segments[2] as u8,
+        ));
+    }
+
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+    use std::net::{TcpListener, TcpStream};
+    use std::thread;
+    use ureq::Resolver as _;
+
+    const PREFIX: &str = "/__ext__/";
+
+    #[test]
+    fn keeps_public_urls_and_query_strings() {
+        let raw = "/__ext__/https://stremio-server.example/hlsv2/probe?mediaURL=magnet%3Ax&audioCodecs=mp3";
+        assert_eq!(
+            external_target(raw, PREFIX).unwrap().as_str(),
+            "https://stremio-server.example/hlsv2/probe?mediaURL=magnet%3Ax&audioCodecs=mp3"
+        );
+        assert!(external_target("/__ext__/http://1.1.1.1/manifest.json", PREFIX).is_ok());
+        assert!(external_target("/__ext__/https://[2606:4700:4700::1111]/", PREFIX).is_ok());
+    }
+
+    #[test]
+    fn rejects_invalid_targets_and_credentials() {
+        for raw in [
+            "/scripts/main.js?v=1",
+            "/__ext__/",
+            "/__ext__/not a url",
+            "/__ext__/file:///etc/passwd",
+            "/__ext__/https://user@example.com/",
+            "/__ext__/https://user:password@example.com/",
+        ] {
+            assert!(external_target(raw, PREFIX).is_err(), "accepted {raw}");
+        }
+    }
+
+    #[test]
+    fn rejects_localhost_names() {
+        for raw in [
+            "/__ext__/http://localhost/",
+            "/__ext__/http://LOCALHOST./",
+            "/__ext__/http://service.localhost/",
+        ] {
+            assert_eq!(
+                external_target(raw, PREFIX),
+                Err(ExternalTargetError::Blocked),
+                "accepted {raw}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_non_public_ipv4_targets() {
+        for address in [
+            "0.0.0.0",
+            "10.0.0.1",
+            "100.64.0.1",
+            "127.0.0.1",
+            "169.254.169.254",
+            "172.16.0.1",
+            "192.0.0.1",
+            "192.0.2.1",
+            "192.88.99.1",
+            "192.168.1.1",
+            "198.18.0.1",
+            "198.51.100.1",
+            "203.0.113.1",
+            "224.0.0.1",
+            "255.255.255.255",
+            "2130706433",
+            "0177.0.0.1",
+            "0x7f000001",
+        ] {
+            let raw = format!("/__ext__/http://{address}/");
+            assert_eq!(
+                external_target(&raw, PREFIX),
+                Err(ExternalTargetError::Blocked),
+                "accepted {address}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_non_public_ipv6_targets() {
+        for address in [
+            "::",
+            "::1",
+            "::ffff:127.0.0.1",
+            "64:ff9b::a00:1",
+            "100::1",
+            "2001:db8::1",
+            "3fff::1",
+            "5f00::1",
+            "fc00::1",
+            "fe80::1",
+            "fec0::1",
+            "ff02::1",
+        ] {
+            let raw = format!("/__ext__/http://[{address}]/");
+            assert_eq!(
+                external_target(&raw, PREFIX),
+                Err(ExternalTargetError::Blocked),
+                "accepted {address}"
+            );
+        }
+    }
+
+    #[test]
+    fn resolver_rejects_any_mixed_private_answer() {
+        let addresses = vec![
+            "93.184.216.34:443".parse().unwrap(),
+            "127.0.0.1:443".parse().unwrap(),
+        ];
+        let error = validate_resolved_addresses(addresses).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+    }
+
+    #[test]
+    fn resolver_accepts_public_answers() {
+        let addresses = vec![
+            "93.184.216.34:443".parse().unwrap(),
+            "[2606:4700:4700::1111]:443".parse().unwrap(),
+        ];
+        assert_eq!(
+            validate_resolved_addresses(addresses.clone()).unwrap(),
+            addresses
+        );
+    }
+
+    #[test]
+    fn redirect_to_private_address_is_rejected_by_connection_resolver() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let server_address = listener.local_addr().unwrap();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            read_request(&mut stream);
+            stream
+                .write_all(
+                    b"HTTP/1.1 302 Found\r\nLocation: http://127.0.0.1:9/private\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                )
+                .unwrap();
+        });
+
+        let resolver = move |netloc: &str| {
+            if netloc.starts_with("public.test:") {
+                Ok(vec![server_address])
+            } else {
+                PublicResolver.resolve(netloc)
+            }
+        };
+        let agent = ureq::AgentBuilder::new()
+            .try_proxy_from_env(false)
+            .resolver(resolver)
+            .build();
+        let error = agent
+            .get(&format!("http://public.test:{}/", server_address.port()))
+            .call()
+            .unwrap_err();
+
+        server.join().unwrap();
+        let ureq::Error::Transport(error) = error else {
+            panic!("expected transport error");
+        };
+        assert!(is_blocked_destination_error(&error));
+    }
+
+    fn read_request(stream: &mut TcpStream) {
+        let mut request = [0; 1024];
+        let _ = stream.read(&mut request).unwrap();
+    }
+}


### PR DESCRIPTION
## Summary

- validate external proxy targets as HTTP(S) URLs and reject credentials
- block loopback, private, link-local, reserved, multicast, and other non-public IPv4/IPv6 destinations
- validate the actual DNS results used for the connection, including every redirect, to prevent DNS rebinding and redirect bypasses
- disable environment-proxy discovery so requests cannot bypass destination validation
- return generic 400/502 responses without exposing transport details
- document the security fix in the changelog

## Tests

- `cargo check --all-targets`
- `cargo test` (17 passed)
- SSRF coverage includes alternate numeric IPv4 forms, mixed public/private DNS answers, IPv4-mapped IPv6, and a public redirect to `127.0.0.1`
- Clippy passes for the changed code when allowing the five existing warnings already present on `development`

Closes #65