### PR TITLE
fix: reload frontend after service worker update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 - Block the external HTTP proxy from reaching loopback, private, link-local, and other non-public
   destinations, including through DNS answers and redirects (#65)
+- Reload the active WebView when a newly installed service worker takes control, preventing an old
+  cached frontend from requesting removed hashed chunks and leaving the application on a dark screen
 
 ## [0.3.3] - 2026-07-31
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -199,6 +199,7 @@ fn create_window(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>>
         .title("Stremio Horizon")
         .inner_size(1280.0, 800.0)
         .min_inner_size(900.0, 600.0)
+        .initialization_script(SERVICE_WORKER_UPDATE_BRIDGE)
         .initialization_script(FULLSCREEN_BRIDGE)
         .initialization_script(FETCH_INTERCEPTOR);
 
@@ -225,6 +226,22 @@ fn create_window(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>>
 
     Ok(())
 }
+
+// This runs before the bundled frontend, including when WebKit serves an older cached entry point.
+// Once the new service worker takes control, reload into its matching precached asset set instead
+// of letting the old page request hashed chunks that no longer exist in the new application.
+const SERVICE_WORKER_UPDATE_BRIDGE: &str = r#"
+(function() {
+    if (!('serviceWorker' in navigator)) return;
+
+    let reloading = false;
+    navigator.serviceWorker.addEventListener('controllerchange', function() {
+        if (reloading) return;
+        reloading = true;
+        window.location.reload();
+    });
+})();
+"#;
 
 const FULLSCREEN_BRIDGE: &str = r#"
 (function() {


### PR DESCRIPTION
## Summary
- install a native initialization bridge before any cached frontend code runs
- reload once when a newly installed service worker takes control
- prevent stale entry points from requesting removed hashed chunks and leaving a dark screen after updates

## Validation
- `cargo check`
- `cargo test` (17 tests)
- reproduced the stale-service-worker failure in the packaged macOS application before applying the fix

`cargo fmt --check` still reports pre-existing formatting differences across the crate; this patch does not reformat unrelated files.