### PR TITLE
feat: add native Discord Rich Presence

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -425,7 +425,7 @@ checksum = "d38f2da7a0a2c4ccf0065be06397cc26a81f4e528be095826eee9d4adbb8c60f"
 dependencies = [
  "byteorder",
  "fnv",
- "uuid",
+ "uuid 1.20.0",
 ]
 
 [[package]]
@@ -715,6 +715,21 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "discord-rich-presence"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90c55d69cab17c19677ce3a5f8face993a9e6eaf847fecac3547f3a3ff4a2494"
+dependencies = [
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "thiserror 2.0.18",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -3291,7 +3306,7 @@ dependencies = [
  "serde",
  "serde_json",
  "url",
- "uuid",
+ "uuid 1.20.0",
 ]
 
 [[package]]
@@ -3698,6 +3713,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 name = "stremio-horizon-app"
 version = "0.3.4"
 dependencies = [
+ "discord-rich-presence",
  "mdns-sd",
  "native-tls",
  "serde",
@@ -3983,7 +3999,7 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "url",
- "uuid",
+ "uuid 1.20.0",
  "walkdir",
 ]
 
@@ -4159,7 +4175,7 @@ dependencies = [
  "toml 0.9.11+spec-1.1.0",
  "url",
  "urlpattern",
- "uuid",
+ "uuid 1.20.0",
  "walkdir",
 ]
 
@@ -4723,6 +4739,15 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "uuid"
@@ -5675,7 +5700,7 @@ dependencies = [
  "serde_repr",
  "tracing",
  "uds_windows",
- "uuid",
+ "uuid 1.20.0",
  "windows-sys 0.61.2",
  "winnow 0.7.14",
  "zbus_macros",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,6 +26,7 @@ native-tls = "0.2"
 mdns-sd = "0.11"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
+discord-rich-presence = "1.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_Security", "Win32_System_JobObjects"] }

--- a/src-tauri/src/discord.rs
+++ b/src-tauri/src/discord.rs
@@ -1,0 +1,168 @@
+use discord_rich_presence::{
+    activity::{Activity, ActivityType, Assets, Timestamps},
+    DiscordIpc, DiscordIpcClient,
+};
+use serde::Deserialize;
+use std::sync::Mutex;
+use tauri::{AppHandle, Manager, State};
+
+// This is the existing Stremio Discord application. Activity::name overrides the
+// displayed activity name so the fork is identified as Stremio Horizon.
+const DISCORD_CLIENT_ID: &str = "997798118185771059";
+
+#[derive(Default)]
+pub struct DiscordManager {
+    client: Mutex<Option<DiscordIpcClient>>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiscordActivityRequest {
+    state: String,
+    details: String,
+    image: Option<String>,
+    start_timestamp: Option<i64>,
+    end_timestamp: Option<i64>,
+}
+
+impl DiscordManager {
+    fn connect(&self) -> Result<bool, String> {
+        let mut client = self
+            .client
+            .lock()
+            .map_err(|_| "Discord state is unavailable")?;
+        if client.is_some() {
+            return Ok(true);
+        }
+
+        let mut next = DiscordIpcClient::new(DISCORD_CLIENT_ID);
+        next.connect()
+            .map_err(|error| format!("failed to connect to Discord: {error}"))?;
+        *client = Some(next);
+        Ok(true)
+    }
+
+    fn disconnect(&self) {
+        let Ok(mut client) = self.client.lock() else {
+            return;
+        };
+        if let Some(mut connected) = client.take() {
+            let _ = connected.clear_activity();
+            let _ = connected.close();
+        }
+    }
+
+    fn clear_activity(&self) -> Result<(), String> {
+        self.with_client(|client| client.clear_activity())
+    }
+
+    fn set_activity(&self, request: &DiscordActivityRequest) -> Result<(), String> {
+        self.with_client(|client| {
+            let mut activity = Activity::new()
+                .name("Stremio Horizon")
+                .activity_type(ActivityType::Watching)
+                .state(request.state.trim())
+                .details(request.details.trim());
+
+            if let Some(image) = request
+                .image
+                .as_deref()
+                .filter(|image| !image.trim().is_empty())
+            {
+                activity = activity.assets(
+                    Assets::new()
+                        .large_image(image.trim())
+                        .large_text(request.details.trim()),
+                );
+            }
+
+            if request.start_timestamp.is_some() || request.end_timestamp.is_some() {
+                let mut timestamps = Timestamps::new();
+                if let Some(start) = request.start_timestamp {
+                    timestamps = timestamps.start(start);
+                }
+                if let Some(end) = request.end_timestamp {
+                    timestamps = timestamps.end(end);
+                }
+                activity = activity.timestamps(timestamps);
+            }
+
+            client.set_activity(activity)
+        })
+    }
+
+    fn with_client<T>(
+        &self,
+        operation: impl FnOnce(&mut DiscordIpcClient) -> Result<T, discord_rich_presence::error::Error>,
+    ) -> Result<T, String> {
+        let mut guard = self
+            .client
+            .lock()
+            .map_err(|_| "Discord state is unavailable")?;
+        let Some(client) = guard.as_mut() else {
+            return Err("Discord is not connected".to_owned());
+        };
+
+        match operation(client) {
+            Ok(value) => Ok(value),
+            Err(error) => {
+                let _ = client.close();
+                *guard = None;
+                Err(format!("Discord RPC failed: {error}"))
+            }
+        }
+    }
+}
+
+#[tauri::command]
+pub fn discord_connect(manager: State<'_, DiscordManager>) -> Result<bool, String> {
+    manager.connect()
+}
+
+#[tauri::command]
+pub fn discord_disconnect(manager: State<'_, DiscordManager>) {
+    manager.disconnect();
+}
+
+#[tauri::command]
+pub fn discord_set_activity(
+    manager: State<'_, DiscordManager>,
+    activity: DiscordActivityRequest,
+) -> Result<(), String> {
+    manager.set_activity(&activity)
+}
+
+#[tauri::command]
+pub fn discord_clear_activity(manager: State<'_, DiscordManager>) -> Result<(), String> {
+    manager.clear_activity()
+}
+
+pub fn shutdown(app: &AppHandle) {
+    app.state::<DiscordManager>().disconnect();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DiscordActivityRequest;
+
+    #[test]
+    fn deserializes_frontend_activity_payload() {
+        let request: DiscordActivityRequest = serde_json::from_value(serde_json::json!({
+            "state": "Watching",
+            "details": "Hunter x Hunter · S1:E57",
+            "image": "https://example.com/episode.jpg",
+            "startTimestamp": 1_700_000_000,
+            "endTimestamp": 1_700_001_200
+        }))
+        .unwrap();
+
+        assert_eq!(request.state, "Watching");
+        assert_eq!(request.details, "Hunter x Hunter · S1:E57");
+        assert_eq!(
+            request.image.as_deref(),
+            Some("https://example.com/episode.jpg")
+        );
+        assert_eq!(request.start_timestamp, Some(1_700_000_000));
+        assert_eq!(request.end_timestamp, Some(1_700_001_200));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ use threadpool::ThreadPool;
 mod chromecast;
 mod config;
 mod debug;
+mod discord;
 mod downloads;
 mod proxy_security;
 mod updater;
@@ -129,6 +130,7 @@ pub fn run() {
         .plugin(tauri_plugin_updater::Builder::new().build())
         .manage(Mutex::new(chromecast::CastManagerState::default()))
         .manage(updater::SharedUpdateState::default())
+        .manage(discord::DiscordManager::default())
         .manage(downloads::DownloadManager::default())
         .manage(Mutex::new(None::<ServiceProcess>))
         .invoke_handler(tauri::generate_handler![
@@ -143,6 +145,10 @@ pub fn run() {
             updater::get_pending_update,
             updater::get_auto_update_enabled,
             updater::set_auto_update_enabled,
+            discord::discord_connect,
+            discord::discord_disconnect,
+            discord::discord_set_activity,
+            discord::discord_clear_activity,
             downloads::download_start,
             downloads::download_list,
             downloads::download_playback_url,
@@ -183,6 +189,7 @@ pub fn run() {
 
     app.run(|app, event| {
         if let RunEvent::Exit = event {
+            discord::shutdown(app);
             if let Some(mut svc) = app.state::<ServiceState>().lock().unwrap().take() {
                 svc.kill();
             }


### PR DESCRIPTION
## Résumé

- ajoute un client Discord IPC natif macOS, Windows et Linux
- expose connexion, déconnexion, mise à jour et nettoyage de présence à Tauri
- nettoie la présence et ferme Discord RPC à la sortie
- utilise le titre, le visuel et les timestamps de lecture fournis par le frontend

Dépend de Aqu1tain/stremio-horizon#69.

Closes #22

## Validation

- cargo check passe
- test Rust du payload passe
- bundle macOS release construit et lancé
