### PR TITLE
chore: release v0.3.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,9 @@ on:
   workflow_dispatch:
     inputs:
       frontend_version:
-        description: 'stremio-horizon release tag to bundle (e.g. v0.1.6)'
+        description: 'stremio-horizon release tag to bundle (e.g. v0.1.7)'
         required: true
-        default: 'v0.1.6'
+        default: 'v0.1.7'
       service_version:
         description: 'stremio-service fork tag to build (e.g. v0.1.0-horizon.2)'
         required: true
@@ -28,7 +28,7 @@ jobs:
           unzip stremio-web.zip
         env:
           GH_TOKEN: ${{ github.token }}
-          FRONTEND_VERSION: ${{ inputs.frontend_version || 'v0.1.6' }}
+          FRONTEND_VERSION: ${{ inputs.frontend_version || 'v0.1.7' }}
 
       - uses: actions/upload-artifact@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+## [0.3.5] - 2026-08-01
+
 ### Added
 
 - Secure persistent download manager with resumable transfers, progress events, downloaded metadata
@@ -14,6 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Offline HLS downloads that keep one selected video quality with its audio, subtitle, encryption-key
   and initialization resources, while preserving pause and resume (#23)
 - Persist content, episode and season identities so the frontend can group downloaded versions reliably
+- Native Discord Rich Presence over Discord IPC on macOS, Windows and Linux, with activity cleanup when
+  the option is disabled or the application exits (#22)
+
+### Changed
+
+- Updated frontend to stremio-horizon v0.1.7
 
 ### Fixed
 
@@ -163,7 +171,8 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Use fixed port to persist session across restarts
 - Bypass CORS for stremio-service communication
 
-[Unreleased]: https://github.com/Aqu1tain/stremio-horizon-app/compare/v0.3.4...HEAD
+[Unreleased]: https://github.com/Aqu1tain/stremio-horizon-app/compare/v0.3.5...HEAD
+[0.3.5]: https://github.com/Aqu1tain/stremio-horizon-app/compare/v0.3.4...v0.3.5
 [0.3.4]: https://github.com/Aqu1tain/stremio-horizon-app/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/Aqu1tain/stremio-horizon-app/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/Aqu1tain/stremio-horizon-app/compare/v0.3.1...v0.3.2

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3711,7 +3711,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stremio-horizon-app"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "discord-rich-presence",
  "mdns-sd",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stremio-horizon-app"
-version = "0.3.4"
+version = "0.3.5"
 description = "Desktop app for Stremio Horizon"
 authors = ["Aqu1tain"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Stremio Horizon",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "identifier": "com.aqu1tain.stremio-horizon",
   "build": {
     "frontendDist": "../dist"


### PR DESCRIPTION
## Summary
- bump the desktop app to v0.3.5
- bundle the released stremio-horizon v0.1.7 frontend
- document the native offline download manager and Discord Rich Presence

## Validation
- cargo check
- cargo test (29 tests)
- frontend archive availability is verified before tagging the app