### PR TITLE
fix: force VLC subtitles off when disabled

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,9 @@ on:
   workflow_dispatch:
     inputs:
       frontend_version:
-        description: 'stremio-horizon release tag to bundle (e.g. v0.1.9)'
+        description: 'stremio-horizon release tag to bundle (e.g. v0.1.10)'
         required: true
-        default: 'v0.1.9'
+        default: 'v0.1.10'
       service_version:
         description: 'stremio-service fork tag to build (e.g. v0.1.0-horizon.2)'
         required: true
@@ -28,7 +28,7 @@ jobs:
           unzip stremio-web.zip
         env:
           GH_TOKEN: ${{ github.token }}
-          FRONTEND_VERSION: ${{ inputs.frontend_version || 'v0.1.9' }}
+          FRONTEND_VERSION: ${{ inputs.frontend_version || 'v0.1.10' }}
 
       - uses: actions/upload-artifact@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [0.4.2] - 2026-08-30
 
+### Changed
+
+- Updated frontend to stremio-horizon v0.1.10
+
 ### Fixed
 
 - Force VLC's subtitle renderer off when Horizon's subtitle language is set to None, preventing
   VLC on Windows from restoring a previously selected subtitle track
+- Explicitly persist watched completion before VLC advances to the next episode or leaves the
+  player
 
 ## [0.4.1] - 2026-08-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-08-30
+
+### Fixed
+
+- Force VLC's subtitle renderer off when Horizon's subtitle language is set to None, preventing
+  VLC on Windows from restoring a previously selected subtitle track
+
 ## [0.4.1] - 2026-08-29
 
 ### Added
@@ -200,7 +207,8 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Use fixed port to persist session across restarts
 - Bypass CORS for stremio-service communication
 
-[Unreleased]: https://github.com/Aqu1tain/stremio-horizon-app/compare/v0.4.1...HEAD
+[Unreleased]: https://github.com/Aqu1tain/stremio-horizon-app/compare/v0.4.2...HEAD
+[0.4.2]: https://github.com/Aqu1tain/stremio-horizon-app/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/Aqu1tain/stremio-horizon-app/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/Aqu1tain/stremio-horizon-app/compare/v0.3.5...v0.4.0
 [0.3.5]: https://github.com/Aqu1tain/stremio-horizon-app/compare/v0.3.4...v0.3.5

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3711,7 +3711,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stremio-horizon-app"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "base64 0.22.1",
  "discord-rich-presence",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stremio-horizon-app"
-version = "0.4.1"
+version = "0.4.2"
 description = "Desktop app for Stremio Horizon"
 authors = ["Aqu1tain"]
 edition = "2021"

--- a/src-tauri/src/vlc.rs
+++ b/src-tauri/src/vlc.rs
@@ -224,6 +224,9 @@ fn playback_preference_args(request: &VlcPlaybackRequest) -> Result<Vec<String>,
             args.push(format!("--sub-file={subtitle_url}"));
         }
     } else {
+        // VLC on Windows can restore its last subtitle choice even with sub-track=-1.
+        // Disabling the subpicture output makes the application's "None" setting authoritative.
+        args.push("--no-spu".to_owned());
         args.push("--sub-track=-1".to_owned());
         args.push("--no-sub-autodetect-file".to_owned());
     }
@@ -414,7 +417,7 @@ mod tests {
 
         assert_eq!(
             playback_preference_args(&request).unwrap(),
-            vec!["--sub-track=-1", "--no-sub-autodetect-file"]
+            vec!["--no-spu", "--sub-track=-1", "--no-sub-autodetect-file"]
         );
     }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Stremio Horizon",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "identifier": "com.aqu1tain.stremio-horizon",
   "build": {
     "frontendDist": "../dist"


### PR DESCRIPTION
## Summary

- disable VLC subpicture rendering when Horizon subtitles are set to None
- keep the existing track deselection and subtitle autodetection safeguards
- release the Windows subtitle hotfix as v0.4.2

## Validation

- 36 native tests
- `cargo check`
- rustfmt check
- VLC 3.0.21 accepts the `--no-spu` launch option on macOS
- Windows and Linux CI required before merge